### PR TITLE
[Feat/#7] 링크 클립이동 api

### DIFF
--- a/toaster-adapter/build.gradle
+++ b/toaster-adapter/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
     implementation(project(":toaster-application"))
+    implementation project(":toaster-common")
+    annotationProcessor project(":toaster-common")
     implementation(project(":toaster-domain"))
-    implementation(project(":toaster-common"))
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -10,4 +11,10 @@ dependencies {
 
     // JSoup
     implementation 'org.jsoup:jsoup:1.15.3'
+
+    //QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }

--- a/toaster-adapter/src/main/java/com/app/toaster/in/api/creat_toast/controller/CreateToastController.java
+++ b/toaster-adapter/src/main/java/com/app/toaster/in/api/creat_toast/controller/CreateToastController.java
@@ -1,4 +1,4 @@
-package com.app.toaster.in.api.toast.controller;
+package com.app.toaster.in.api.creat_toast.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.app.toaster.dto.ApiResponse;
 import com.app.toaster.exception.Success;
-import com.app.toaster.in.api.toast.reqeust.CreateToastDto;
+import com.app.toaster.in.api.creat_toast.reqeust.CreateToastDto;
 import com.app.toaster.toast.port.in.CreateToastUseCase;
 import com.app.toaster.toast.port.in.command.CreateToastCommand;
 
@@ -23,11 +23,11 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/v2/toast")
 @Validated
 @Tag(name = "Toast", description = "토스트(링크 저장) 관련 API")
-class ToastController {
+class CreateToastController {
 	private final CreateToastUseCase createToastUseCase;
 
 	@Operation(summary = "토스트 생성", description = "새로운 링크 저장")
-	@PostMapping("/save")
+	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
 	public ApiResponse createToast(
 		// @UserId Long userId,

--- a/toaster-adapter/src/main/java/com/app/toaster/in/api/creat_toast/reqeust/CreateToastDto.java
+++ b/toaster-adapter/src/main/java/com/app/toaster/in/api/creat_toast/reqeust/CreateToastDto.java
@@ -1,4 +1,4 @@
-package com.app.toaster.in.api.toast.reqeust;
+package com.app.toaster.in.api.creat_toast.reqeust;
 
 import jakarta.annotation.Nullable;
 

--- a/toaster-adapter/src/main/java/com/app/toaster/in/api/move_clip/controller/MoveToastClipController.java
+++ b/toaster-adapter/src/main/java/com/app/toaster/in/api/move_clip/controller/MoveToastClipController.java
@@ -1,0 +1,46 @@
+package com.app.toaster.in.api.move_clip.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+import com.app.toaster.in.api.move_clip.reqeust.MoveClipRequest;
+import com.app.toaster.move_clip.port.in.MoveClipCommand;
+import com.app.toaster.move_clip.port.in.MoveClipUseCase;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/toast")
+@Validated
+@Tag(name = "Toast", description = "토스트(링크 저장) 관련 API")
+class MoveToastClipController {
+	private final MoveClipUseCase moveClipUseCase;
+
+	@Operation(summary = "토스트 클립 이동", description = "1개이상의 토스트 특정 클립으로 이동")
+	@PatchMapping("/clip")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse createToast(
+		// @UserId Long userId,
+		@RequestBody MoveClipRequest request
+	) {
+		// todo-mh 임의로 userId 1L로 설정, 추후 변경
+		MoveClipCommand command = new MoveClipCommand(
+			1L,
+			request.toastIds(),
+			request.targetClipId()
+		);
+
+		moveClipUseCase.moveClip(command);
+		return ApiResponse.success(Success.UPDATE_TOAST_CLIP_SUCCESS);
+	}
+}

--- a/toaster-adapter/src/main/java/com/app/toaster/in/api/move_clip/reqeust/MoveClipRequest.java
+++ b/toaster-adapter/src/main/java/com/app/toaster/in/api/move_clip/reqeust/MoveClipRequest.java
@@ -1,0 +1,8 @@
+package com.app.toaster.in.api.move_clip.reqeust;
+
+import java.util.List;
+
+import jakarta.annotation.Nullable;
+
+public record MoveClipRequest(List<Long> toastIds, Long targetClipId) {
+}

--- a/toaster-adapter/src/main/java/com/app/toaster/out/persistence/clip/ClipPersistenceAdapter.java
+++ b/toaster-adapter/src/main/java/com/app/toaster/out/persistence/clip/ClipPersistenceAdapter.java
@@ -2,13 +2,13 @@ package com.app.toaster.out.persistence.clip;
 
 import org.springframework.stereotype.Component;
 
-import com.app.toaster.toast.port.out.LoadClipPort;
+import com.app.toaster.common.clip.port.out.CheckClipOwnerPort;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class ClipPersistenceAdapter implements LoadClipPort {
+public class ClipPersistenceAdapter implements CheckClipOwnerPort {
 
     private final ClipRepository clipRepository;
 

--- a/toaster-adapter/src/main/java/com/app/toaster/out/persistence/toast/ToastPersistenceAdapter.java
+++ b/toaster-adapter/src/main/java/com/app/toaster/out/persistence/toast/ToastPersistenceAdapter.java
@@ -1,7 +1,10 @@
 package com.app.toaster.out.persistence.toast;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
+import com.app.toaster.move_clip.port.out.UpdateToastClipPort;
 import com.app.toaster.toast.model.Toast;
 import com.app.toaster.toast.port.out.SaveToastPort;
 
@@ -9,13 +12,19 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class ToastPersistenceAdapter implements SaveToastPort {
+public class ToastPersistenceAdapter implements SaveToastPort, UpdateToastClipPort {
 
 	private final ToastRepository toastRepository;
+	private final ToastQueryRepository toastQueryRepository;
 
 	@Override
 	public void save(Toast toast) {
 		ToastEntity entity = ToastMapper.toEntity(toast);
 		toastRepository.save(entity);
+	}
+
+	@Override
+	public void updateToastClip(List<Long> ids, Long clipId) {
+		toastQueryRepository.bulkUpdateClipIdByIds(ids, clipId);
 	}
 }

--- a/toaster-adapter/src/main/java/com/app/toaster/out/persistence/toast/ToastQueryRepository.java
+++ b/toaster-adapter/src/main/java/com/app/toaster/out/persistence/toast/ToastQueryRepository.java
@@ -1,0 +1,7 @@
+package com.app.toaster.out.persistence.toast;
+
+import java.util.List;
+
+public interface ToastQueryRepository {
+    long bulkUpdateClipIdByIds(List<Long> toastIds, Long targetClipId);
+}

--- a/toaster-adapter/src/main/java/com/app/toaster/out/persistence/toast/ToastQueryRepositoryImpl.java
+++ b/toaster-adapter/src/main/java/com/app/toaster/out/persistence/toast/ToastQueryRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.app.toaster.out.persistence.toast;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class ToastQueryRepositoryImpl implements ToastQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QToastEntity toast = QToastEntity.toastEntity;
+
+    @Override
+    public long bulkUpdateClipIdByIds(List<Long> toastIds, Long targetClipId) {
+        return queryFactory
+            .update(toast)
+            .set(toast.clipId, targetClipId)
+            .where(toast.id.in(toastIds))
+            .execute();
+    }
+}

--- a/toaster-application/src/main/java/com/app/toaster/common/clip/port/out/CheckClipOwnerPort.java
+++ b/toaster-application/src/main/java/com/app/toaster/common/clip/port/out/CheckClipOwnerPort.java
@@ -1,0 +1,5 @@
+package com.app.toaster.common.clip.port.out;
+
+public interface CheckClipOwnerPort {
+	boolean existsByIdAndUserId(Long clipId, Long userId);
+}

--- a/toaster-application/src/main/java/com/app/toaster/move_clip/port/in/MoveClipCommand.java
+++ b/toaster-application/src/main/java/com/app/toaster/move_clip/port/in/MoveClipCommand.java
@@ -1,0 +1,6 @@
+package com.app.toaster.move_clip.port.in;
+
+import java.util.List;
+
+public record MoveClipCommand(Long userId, List<Long> toastIds, Long targetClipId) {
+}

--- a/toaster-application/src/main/java/com/app/toaster/move_clip/port/in/MoveClipUseCase.java
+++ b/toaster-application/src/main/java/com/app/toaster/move_clip/port/in/MoveClipUseCase.java
@@ -1,0 +1,6 @@
+package com.app.toaster.move_clip.port.in;
+
+public interface MoveClipUseCase {
+
+	public void moveClip(MoveClipCommand command);
+}

--- a/toaster-application/src/main/java/com/app/toaster/move_clip/port/out/UpdateToastClipPort.java
+++ b/toaster-application/src/main/java/com/app/toaster/move_clip/port/out/UpdateToastClipPort.java
@@ -1,0 +1,8 @@
+package com.app.toaster.move_clip.port.out;
+
+import java.util.List;
+
+public interface UpdateToastClipPort {
+
+	void updateToastClip(List<Long> ids, Long clipId);
+}

--- a/toaster-application/src/main/java/com/app/toaster/move_clip/service/MoveClipService.java
+++ b/toaster-application/src/main/java/com/app/toaster/move_clip/service/MoveClipService.java
@@ -1,0 +1,35 @@
+package com.app.toaster.move_clip.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.app.toaster.common.clip.port.out.CheckClipOwnerPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.move_clip.port.in.MoveClipCommand;
+import com.app.toaster.move_clip.port.in.MoveClipUseCase;
+import com.app.toaster.move_clip.port.out.UpdateToastClipPort;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MoveClipService implements MoveClipUseCase {
+	private final CheckClipOwnerPort checkClipOwnerPort;
+	private final UpdateToastClipPort updateToastClipPort;
+
+	@Override
+	@Transactional
+	public void moveClip(MoveClipCommand command) {
+		validate(command.userId(), command.targetClipId());
+		updateToastClipPort.updateToastClip(command.toastIds(), command.targetClipId());
+	}
+
+	private void validate(Long userId, Long clipId) {
+		if (clipId != null && !checkClipOwnerPort.existsByIdAndUserId(clipId, userId)) {
+			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 클립이 아닙니다.");
+		}
+	}
+}

--- a/toaster-application/src/main/java/com/app/toaster/toast/port/out/LoadClipPort.java
+++ b/toaster-application/src/main/java/com/app/toaster/toast/port/out/LoadClipPort.java
@@ -1,5 +1,0 @@
-package com.app.toaster.toast.port.out;
-
-public interface LoadClipPort {
-	boolean existsByIdAndUserId(Long clipId, Long userId);
-}

--- a/toaster-application/src/main/java/com/app/toaster/toast/service/SaveToastService.java
+++ b/toaster-application/src/main/java/com/app/toaster/toast/service/SaveToastService.java
@@ -11,7 +11,7 @@ import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.toast.model.Toast;
 import com.app.toaster.toast.port.in.CreateToastUseCase;
 import com.app.toaster.toast.port.in.command.CreateToastCommand;
-import com.app.toaster.toast.port.out.LoadClipPort;
+import com.app.toaster.common.clip.port.out.CheckClipOwnerPort;
 import com.app.toaster.toast.port.out.LoadUserPort;
 import com.app.toaster.toast.port.out.ParseOgTagPort;
 import com.app.toaster.toast.port.out.ParsedOgResult;
@@ -28,7 +28,7 @@ public class SaveToastService implements CreateToastUseCase {
 	private final SaveToastPort saveToastPort;
 	private final ParseOgTagPort parseOgTagPort;
 	private final LoadUserPort loadUserPort;
-	private final LoadClipPort loadClipPort;
+	private final CheckClipOwnerPort checkClipOwnerPort;
 
 	@Value("${static-image.root}")
 	private String BASIC_ROOT;
@@ -52,7 +52,7 @@ public class SaveToastService implements CreateToastUseCase {
 			throw new CustomException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage());
 		}
 
-		if (clipId != null && !loadClipPort.existsByIdAndUserId(clipId, userId)) {
+		if (clipId != null && !checkClipOwnerPort.existsByIdAndUserId(clipId, userId)) {
 			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 클립이 아닙니다.");
 		}
 	}

--- a/toaster-common/build.gradle
+++ b/toaster-common/build.gradle
@@ -9,4 +9,10 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
+    //QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }

--- a/toaster-common/src/main/java/com/app/toaster/config/QueryDslConfig.java
+++ b/toaster-common/src/main/java/com/app/toaster/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.app.toaster.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/toaster-common/src/main/java/com/app/toaster/exception/Success.java
+++ b/toaster-common/src/main/java/com/app/toaster/exception/Success.java
@@ -43,6 +43,7 @@ public enum Success {
 	PARSING_OG_SUCCESS(HttpStatus.OK, "og 데이터 파싱 결과입니다. 크롤링을 막은 페이지는 기본이미지가 나옵니다."),
 	UPDATE_PUSH_ALLOWED_SUCCESS(HttpStatus.OK, "푸시알림 수정 성공"),
 	UPDATE_TOAST_TITLE_SUCCESS(HttpStatus.OK, "토스트 제목 수정 성공"),
+	UPDATE_TOAST_CLIP_SUCCESS(HttpStatus.OK, "토스트 클립이동 성공"),
 
 	UPDATE_ISREAD_SUCCESS(HttpStatus.OK, "열람여부 수정 완료"),
 	UPDATE_TIMER_DATETIME_SUCCESS(HttpStatus.OK, "타이머 시간/날짜 수정 완료"),

--- a/toaster-domain/build.gradle
+++ b/toaster-domain/build.gradle
@@ -1,3 +1,4 @@
+
 dependencies {
     implementation project(':toaster-common')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'


### PR DESCRIPTION
## 🚩 관련 이슈
- close #7 

## 📋 구현 기능 명세
- [x] 기존 패키지명 수정
- [x] QueryDsl 설정추가
- [x] 클립이동 api

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
1. 기존에 만들었던 create_toast 패키지명 변경했습니다 (controller명과 api path도 함께)
2. 기존에 있던 LoadClipPort(clipId와 userId로 해당 클립이 있는지 검증하는 port)를 더 명확하게 CheckClipOwnerPort 으로 수정하였고 해당 port를 공통으로 쓰는거같아 appliction/common/port/out 에 옮김

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지
1. 위에서 말한 CheckClipOwnerPort 해당 port를 공통으로 쓰는거같아 appliction/common/port/out 에 옮겼는데 괜찮은가요?


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- [Patch] v2/toast/clip
