### PR TITLE
[Feature/#11]

### DIFF
--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/convert_visibility_share_clip/ChangeClipVisibilityResponse.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/convert_visibility_share_clip/ChangeClipVisibilityResponse.java
@@ -1,0 +1,12 @@
+package com.app.toaster.adapter.in.convert_visibility_share_clip;
+
+import com.app.toaster.clip.model.Clip;
+
+public record ChangeClipVisibilityResponse(
+    String result,
+    String afterState
+) {
+    public static ChangeClipVisibilityResponse toResponse(Clip clip){
+        return new ChangeClipVisibilityResponse("Y", clip.getType().name());
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/convert_visibility_share_clip/ConvertVisibilityController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/convert_visibility_share_clip/ConvertVisibilityController.java
@@ -1,0 +1,30 @@
+package com.app.toaster.adapter.in.convert_visibility_share_clip;
+
+import com.app.toaster.application.port.convert_share_clip.in.ChangeClipVisibilityCommand;
+import com.app.toaster.application.port.convert_share_clip.in.ConvertShareClipVisibilityUseCase;
+import com.app.toaster.auth.UserId;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+import com.app.toaster.toast.enums.ClipType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/share-clip")
+class ConvertVisibilityController {
+
+    private final ConvertShareClipVisibilityUseCase useCase;
+
+    @PatchMapping
+    ApiResponse<?> convertVisibilityShareClip(@UserId Long userId, @RequestParam Long clipId, @RequestParam String wantTo){
+        if (ClipType.valueOf(wantTo).equals(ClipType.PRIVATE)){
+            return ApiResponse.success(Success.UPDATE_VISIBILITY_SHARE_CLIP_SUCCESS, useCase.changeShareClipToPrivateClip(ChangeClipVisibilityCommand.toCommand(userId, clipId)));
+        }
+        return ApiResponse.success(Success.UPDATE_VISIBILITY_SHARE_CLIP_SUCCESS, useCase.changePrivateClipToShareClip(ChangeClipVisibilityCommand.toCommand(userId, clipId)));
+    }
+
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/create_share_clip/CreateShareClipController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/create_share_clip/CreateShareClipController.java
@@ -1,0 +1,31 @@
+package com.app.toaster.adapter.in.create_share_clip;
+
+import com.app.toaster.application.port.create_share_clip.in.CreateShareClipCommand;
+import com.app.toaster.application.port.create_share_clip.in.CreateShareClipUseCase;
+import com.app.toaster.auth.UserId;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/share-clip")
+class CreateShareClipController {
+
+    /**
+     * 클립 참가하기에서 생각할점
+     * 링크를 누른사람의 엑세스토큰이 필요. 이때 눌렀는데, 엑세스토큰이 없는사람이면  ??
+     * 엑세스토큰이 있으면 단순히 참가하면 됨.
+     */
+    private final CreateShareClipUseCase createShareClipUseCase;
+
+    @PostMapping
+    ApiResponse<?> createShareClip(@UserId Long userId, @RequestBody CreateShareClipRequest request) {
+        return ApiResponse.success(Success.CREATE_SHARE_CLIP_SUCCESS, createShareClipUseCase.createShareClip(CreateShareClipCommand.toCommand(userId, request)));
+    }
+
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/create_share_clip/CreateShareClipRequest.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/create_share_clip/CreateShareClipRequest.java
@@ -1,0 +1,11 @@
+package com.app.toaster.adapter.in.create_share_clip;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateShareClipRequest(
+    @NotNull(message = "공유클립은 null일 수 없습니다.")
+    @NotBlank(message = "공유클립 제목은 비어있으면 안됩니다." )
+    String title
+) {
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/create_share_clip/CreateShareClipResponse.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/create_share_clip/CreateShareClipResponse.java
@@ -1,0 +1,12 @@
+package com.app.toaster.adapter.in.create_share_clip;
+
+import com.app.toaster.clip.model.Clip;
+
+public record CreateShareClipResponse(
+    String result,
+    Clip clip
+) {
+    public static CreateShareClipResponse toResponse(Clip clip) {
+        return new CreateShareClipResponse("Y", clip);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/controller/CreateToastController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/controller/CreateToastController.java
@@ -1,6 +1,6 @@
-package com.app.toaster.adapter.in.create_toast.in.controller;
+package com.app.toaster.adapter.in.create_toast.controller;
 
-import com.app.toaster.adapter.in.create_toast.in.request.CreateToastDto;
+import com.app.toaster.adapter.in.create_toast.request.CreateToastDto;
 import com.app.toaster.application.port.create_toast.in.CreateToastUseCase;
 import com.app.toaster.application.port.create_toast.in.command.CreateToastCommand;
 import com.app.toaster.dto.ApiResponse;

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/request/CreateToastDto.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/request/CreateToastDto.java
@@ -1,4 +1,4 @@
-package com.app.toaster.adapter.in.create_toast.in.request;
+package com.app.toaster.adapter.in.create_toast.request;
 
 import jakarta.annotation.Nullable;
 

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/load_main_page/LoadMainPageController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/load_main_page/LoadMainPageController.java
@@ -1,0 +1,24 @@
+package com.app.toaster.adapter.in.load_main_page;
+
+import com.app.toaster.application.port.load_mainpage.in.LoadMainPageCommand;
+import com.app.toaster.application.port.load_mainpage.in.LoadMainPageUseCase;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v2/users")
+@RequiredArgsConstructor
+class LoadMainPageController {
+
+    private final LoadMainPageUseCase loadMainPageUseCase;
+
+    @GetMapping("/main")
+    @Deprecated
+    protected ApiResponse<?> LoadUserMainPage(Long userId){ //jwt추가하고 어노테이션으로 변경
+        return ApiResponse.success(Success.GET_SETTINGS_SUCCESS, loadMainPageUseCase.loadMainPage(LoadMainPageCommand.toCommand(userId)));
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/UpdateAllowedPushRequest.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/UpdateAllowedPushRequest.java
@@ -1,0 +1,6 @@
+package com.app.toaster.adapter.in.user_allow_push;
+
+public record UpdateAllowedPushRequest(
+    boolean allowedPush
+) {
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/UpdateAllowedPushResponse.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/UpdateAllowedPushResponse.java
@@ -1,0 +1,9 @@
+package com.app.toaster.adapter.in.user_allow_push;
+
+public record UpdateAllowedPushResponse(
+    boolean isAllowed
+) {
+    public static UpdateAllowedPushResponse toResponse(boolean isAllowed){
+        return new UpdateAllowedPushResponse(isAllowed);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/UserAllowedPushController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/UserAllowedPushController.java
@@ -1,7 +1,7 @@
 package com.app.toaster.adapter.in.user_allow_push;
 
-import com.app.toaster.adapter.in.user_allow_push.command.UpdateAllowedPushCommand;
 import com.app.toaster.application.port.user_allow_push.in.UserAllowPushUseCase;
+import com.app.toaster.application.port.user_allow_push.in.command.UpdateAllowedPushCommand;
 import com.app.toaster.auth.UserId;
 import com.app.toaster.dto.ApiResponse;
 import com.app.toaster.exception.Success;

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/UserAllowedPushController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/UserAllowedPushController.java
@@ -1,0 +1,25 @@
+package com.app.toaster.adapter.in.user_allow_push;
+
+import com.app.toaster.adapter.in.user_allow_push.command.UpdateAllowedPushCommand;
+import com.app.toaster.application.port.user_allow_push.in.UserAllowPushUseCase;
+import com.app.toaster.auth.UserId;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/users")
+class UserAllowedPushController {
+
+    private final UserAllowPushUseCase allowPushUseCase;
+
+    @PatchMapping("/notification")
+    @ResponseStatus(HttpStatus.OK)
+    ApiResponse<?> updateAllowedNotification (@UserId Long userId, @RequestBody @Valid final UpdateAllowedPushRequest requestDto) {
+        return ApiResponse.success(Success.UPDATE_PUSH_ALLOWED_SUCCESS, allowPushUseCase.allowPush(UpdateAllowedPushCommand.ofCommand(userId, requestDto)));
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/command/UpdateAllowedPushCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_allow_push/command/UpdateAllowedPushCommand.java
@@ -1,0 +1,12 @@
+package com.app.toaster.adapter.in.user_allow_push.command;
+
+import com.app.toaster.adapter.in.user_allow_push.UpdateAllowedPushRequest;
+
+public record UpdateAllowedPushCommand(
+    Long userId,
+    boolean allowedPush
+) {
+    public static UpdateAllowedPushCommand ofCommand(Long userId, UpdateAllowedPushRequest request){
+        return new UpdateAllowedPushCommand(userId, request.allowedPush());
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_unique_key/MakeUniqueKeyResponse.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_unique_key/MakeUniqueKeyResponse.java
@@ -1,0 +1,11 @@
+package com.app.toaster.adapter.in.user_unique_key;
+
+public record MakeUniqueKeyResponse(
+    String result,
+    String uniqueKey
+) {
+    public static MakeUniqueKeyResponse success(String uniqueKey) {
+        return new MakeUniqueKeyResponse("Y", uniqueKey);
+    }
+}
+

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_unique_key/UpdateUniqueKeyRequest.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_unique_key/UpdateUniqueKeyRequest.java
@@ -1,0 +1,11 @@
+package com.app.toaster.adapter.in.user_unique_key;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateUniqueKeyRequest(
+    @NotBlank(message = "uniqueKey는 비어있으면 안됩니다.")
+    @NotNull(message = "uniqueKey는 null이면 안됩니다.")
+    String uniqueKey
+) {
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_unique_key/UpdateUniqueKeyResponse.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_unique_key/UpdateUniqueKeyResponse.java
@@ -1,0 +1,12 @@
+package com.app.toaster.adapter.in.user_unique_key;
+
+public record UpdateUniqueKeyResponse(
+    String result
+) {
+    public static UpdateUniqueKeyResponse fail(){
+        return new UpdateUniqueKeyResponse("N");
+    }
+    public static UpdateUniqueKeyResponse success(){
+        return new UpdateUniqueKeyResponse("Y");
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_unique_key/UserUniqueKeyController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_unique_key/UserUniqueKeyController.java
@@ -1,0 +1,39 @@
+package com.app.toaster.adapter.in.user_unique_key;
+
+import com.app.toaster.application.port.make_unique_key.ToasterUniqueKeyUseCase;
+import com.app.toaster.application.port.make_unique_key.in.command.UpdateUniqueKeyCommand;
+import com.app.toaster.auth.UserId;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/users")
+@Validated
+class UserUniqueKeyController {
+
+    private final ToasterUniqueKeyUseCase toasterUniqueKeyUseCase;
+
+    /*
+    uniquekey 생성시 validation 어노테이션으로
+     */
+
+    @PutMapping("/uniquekey")
+    @ResponseStatus(HttpStatus.OK)
+    ApiResponse<?> updateUniqueKey(@UserId Long userId, @Valid @RequestBody UpdateUniqueKeyRequest uniqueKeyRequestDto) {
+        return ApiResponse.success(Success.CREATE_TOAST_SUCCESS, toasterUniqueKeyUseCase.updateUniqueKey(UpdateUniqueKeyCommand.ofCommand(uniqueKeyRequestDto.uniqueKey(), userId)));
+    }
+
+    @PostMapping("/uniquekey")
+    @ResponseStatus(HttpStatus.CREATED)
+    ApiResponse<?> makeUniqueKey() {
+        return ApiResponse.success(Success.CREATE_UNIQUEKEY_SUCCESS, toasterUniqueKeyUseCase.makeUniqueKey());
+    }
+
+
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_update_os/UpdateOsRequestDto.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_update_os/UpdateOsRequestDto.java
@@ -1,0 +1,9 @@
+package com.app.toaster.adapter.in.user_update_os;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateOsRequestDto(
+    @NotBlank(message = "OS가 비어있으면 안됩니다. ANDROID, IOS")
+    String os
+) {
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_update_os/UpdateOsResponseDto.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_update_os/UpdateOsResponseDto.java
@@ -1,0 +1,13 @@
+package com.app.toaster.adapter.in.user_update_os;
+
+public record UpdateOsResponseDto(
+    String result
+) {
+    public static UpdateOsResponseDto fail(){
+        return new UpdateOsResponseDto("N");
+    }
+    public static UpdateOsResponseDto success(){
+        return new UpdateOsResponseDto("Y");
+    }
+
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/user_update_os/UserUpdateOsController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/user_update_os/UserUpdateOsController.java
@@ -1,0 +1,25 @@
+package com.app.toaster.adapter.in.user_update_os;
+
+import com.app.toaster.application.port.user_update_os.in.UpdateOsCommand;
+import com.app.toaster.application.port.user_update_os.in.UpdateOsUseCase;
+import com.app.toaster.auth.UserId;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/users")
+class UserUpdateOsController {
+
+    private final UpdateOsUseCase updateOsUseCase;
+
+    @PatchMapping("/os")
+    @ResponseStatus(HttpStatus.OK)
+    ApiResponse<?> updateAllowedNotification (@UserId Long userId, @RequestBody UpdateOsRequestDto updateOsDto) {
+        return ApiResponse.success(Success.UPDATE_OS_SUCCESS, updateOsUseCase.updateOs(UpdateOsCommand.ofCommand(userId,updateOsDto.os())));
+    }
+
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipEntity.java
@@ -1,19 +1,24 @@
 package com.app.toaster.adapter.out.persistence.clip;
 
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.BadRequestException;
+import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.toast.enums.ClipType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "clip")
 class ClipEntity {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -31,13 +36,77 @@ class ClipEntity {
 
 	private String members;
 
-	private LocalDateTime latestReadTime;
 	@Builder
-	public ClipEntity(String title, Long ownerId, int priority, LocalDateTime latestReadTime) {
+	public ClipEntity(String title, Long ownerId, int priority, ClipType clipType) {
 		this.title = title;
 		this.ownerId = ownerId;
 		this.members = null;
 		this.priority = priority;
-		this.latestReadTime = latestReadTime;
+		this.type = clipType;
 	}
+
+	public void changePrivate() {
+		if (this.type.equals(ClipType.PRIVATE) && !isEmptyMemberList()) { //주인만 있지않은 멤버 리스트는 private으로 못만들게
+			throw new BadRequestException(Error.BAD_REQUEST_VISIBILITY_CLIP, Error.BAD_REQUEST_VISIBILITY_CLIP.getMessage());
+		}
+		this.type = ClipType.PRIVATE;
+		this.members = makeOnlyOwnerState();
+	}
+
+	public void changeShared() {
+		if (this.type.equals(ClipType.SHARED)) {
+			throw new BadRequestException(Error.BAD_REQUEST_VISIBILITY_CLIP, Error.BAD_REQUEST_VISIBILITY_CLIP.getMessage());
+		}
+		this.type = ClipType.SHARED;
+		this.members = makeOnlyOwnerState();
+	}
+
+	public void addMember(Long newMemberId) {
+		ObjectMapper objectMapper = new ObjectMapper();
+		try {
+			List<Long> memberList = objectMapper.convertValue(this.members, List.class);
+			memberList.add(newMemberId);
+			this.members = objectMapper.writeValueAsString(memberList);
+		} catch (Exception e) {
+			throw new CustomException(Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION, Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION.getMessage());
+		}
+	}
+
+	public void exitMember(Long exitMemberId) {
+		ObjectMapper objectMapper = new ObjectMapper();
+		try {
+			List<Long> memberList = objectMapper.convertValue(this.members, List.class);
+			memberList.remove(exitMemberId); //TODO: object로 하긴했는데, 이거 인덱스로 오인하고 지우진않겠지?
+			this.members = objectMapper.writeValueAsString(memberList);
+		} catch (Exception e) {
+			throw new CustomException(Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION, Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION.getMessage());
+		}
+	}
+
+	private String makeOnlyOwnerState() {
+		List<Long> list = List.of(ownerId);
+		ObjectMapper objectMapper = new ObjectMapper();
+		try {
+			return objectMapper.writeValueAsString(list);
+		} catch (Exception e) {
+			throw new CustomException(Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION, Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION.getMessage());
+		}
+	}
+
+	private boolean isEmptyMemberList() {
+		if (members.equals(makeOnlyOwnerState())) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * TODO: 생각해볼점.
+	 * 공유클립을 생성했을 때 기존 클립로직은 다 영향 받을듯.
+	 * 1. 해당 클립 수정 -> 기존 클립 수정 api등도 고려해야함. -> 수정 이벤트 히스토리 테이블에 저장. 참여자와 소유자 모두 수정가능.
+	 * 2. 해당 클립 삭제 -> 만약 참가자들이 존재할경우 -> 삭제할수없다. 참가자들이 없을경우 삭제. 이때 softdelete가 목표힘들면 기존 로직 냅두기. 소유자가 아닌사람은 삭제권한 x
+	 * 3. 클립생성 -> 기존 클립을 생성 + 공유클립테이블에도 생성.
+	 * 4. 클립조회 -> 공유클립 조회할 때 만약 내가 참여한 클립을 띄워야하는데, 이는 인덱스처리할 테이블로 해서 기록해야될듯. 아니면 유저에 공유클립 id리스트를 넣어둘까?
+	 * 5. 클립 나가기 -> 공유클립에서
+	 */
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipEntity.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,11 +30,14 @@ class ClipEntity {
 	private ClipType type;
 
 	private String members;
+
+	private LocalDateTime latestReadTime;
 	@Builder
-	public ClipEntity(String title, Long ownerId, int priority) {
+	public ClipEntity(String title, Long ownerId, int priority, LocalDateTime latestReadTime) {
 		this.title = title;
 		this.ownerId = ownerId;
 		this.members = null;
 		this.priority = priority;
+		this.latestReadTime = latestReadTime;
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipMapper.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipMapper.java
@@ -1,0 +1,17 @@
+package com.app.toaster.adapter.out.persistence.clip;
+
+import com.app.toaster.clip.model.Clip;
+
+public class ClipMapper {
+
+    public static Clip toDomain(ClipEntity clipEntity){
+        return Clip.builder()
+            .id(clipEntity.getId())
+            .title(clipEntity.getTitle())
+            .members(clipEntity.getMembers())
+            .type(clipEntity.getType())
+            .priority(clipEntity.getPriority())
+            .ownerId(clipEntity.getOwnerId())
+            .build();
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipQueryRepository.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipQueryRepository.java
@@ -1,0 +1,6 @@
+package com.app.toaster.adapter.out.persistence.clip;
+
+public interface ClipQueryRepository {
+    Integer findMaxPriorityByOwnerId(Long ownerId);
+    ClipEntity createClipWithMaxPriority(Long userId, String title);
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipQueryRepositoryImpl.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipQueryRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.app.toaster.adapter.out.persistence.clip;
+
+import com.app.toaster.toast.enums.ClipType;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class ClipQueryRepositoryImpl implements ClipQueryRepository{
+
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager entityManager;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Integer findMaxPriorityByOwnerId(Long ownerId) {
+        QClipEntity clip = QClipEntity.clipEntity;
+
+        Integer maxPriority = queryFactory
+            .select(clip.priority.max())
+            .from(clip)
+            .where(clip.ownerId.eq(ownerId)
+                .and(clip.type.eq(ClipType.SHARED)))
+            .fetchOne();
+        return maxPriority != null ? maxPriority : 0;
+    }
+
+    @Override
+    @Transactional
+    public ClipEntity createClipWithMaxPriority(Long userId, String title) {
+        // 1. 현재 최대 priority 조회
+        Integer maxPriority = findMaxPriorityByOwnerId(userId);
+
+        // 2. 새로운 ClipEntity 생성 및 저장
+        ClipEntity clipEntity = ClipEntity.builder()
+            .ownerId(userId)
+            .priority(maxPriority + 1)
+            .title(title)
+            .clipType(ClipType.SHARED)
+            .build();
+
+        entityManager.persist(clipEntity);
+        entityManager.flush(); // 즉시 DB에 반영
+
+        return clipEntity;
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ConvertShareClipAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ConvertShareClipAdapter.java
@@ -1,0 +1,29 @@
+package com.app.toaster.adapter.out.persistence.clip;
+
+import com.app.toaster.application.port.convert_share_clip.out.ConvertShareClipPort;
+import com.app.toaster.clip.model.Clip;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class ConvertShareClipAdapter implements ConvertShareClipPort {
+    private final ClipRepository clipRepository;
+    @Override
+    public Clip convertShareClipToPrivate(Long userId, Long clipId) {
+        ClipEntity clipEntity = clipRepository.findById(clipId)
+            .orElseThrow(() -> new CustomException(Error.NOT_FOUND_CLIP_EXCEPTION, Error.NOT_FOUND_CLIP_EXCEPTION.getMessage()));
+        clipEntity.changePrivate();
+        return ClipMapper.toDomain(clipEntity);
+    }
+
+    @Override
+    public Clip convertPrivateClipToShare(Long userId, Long clipId) {
+        ClipEntity clipEntity = clipRepository.findById(clipId)
+            .orElseThrow(() -> new CustomException(Error.NOT_FOUND_CLIP_EXCEPTION, Error.NOT_FOUND_CLIP_EXCEPTION.getMessage()));
+        clipEntity.changeShared();
+        return ClipMapper.toDomain(clipEntity);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/CreateShareClipAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/CreateShareClipAdapter.java
@@ -1,0 +1,19 @@
+package com.app.toaster.adapter.out.persistence.clip;
+
+import com.app.toaster.application.port.create_share_clip.out.CreateShareClipPort;
+import com.app.toaster.clip.model.Clip;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreateShareClipAdapter implements CreateShareClipPort {
+    private final ClipQueryRepository clipQueryRepository;
+
+    @Override
+    public Clip createShareClip(Long userId, String title) {
+        // 우선순위는 공유클립 중 priority max값 +1
+        ClipEntity shareClipEntity = clipQueryRepository.createClipWithMaxPriority(userId, title);
+        return ClipMapper.toDomain(shareClipEntity);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/mainpage/LoadMainPageAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/mainpage/LoadMainPageAdapter.java
@@ -1,0 +1,28 @@
+package com.app.toaster.adapter.out.persistence.mainpage;
+
+import com.app.toaster.application.port.load_mainpage.out.LoadMainPagePort;
+import com.app.toaster.mainpage.model.MainPage;
+import com.app.toaster.mainpage.vo.MainPageVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LoadMainPageAdapter implements LoadMainPagePort {
+
+    private final MainPageQueryRepository mainPageQueryRepository;
+
+    @Override
+    public MainPage loadMainPageData(Long userId) {
+        MainPageVO queryResult = mainPageQueryRepository.getMainPageData(userId)
+            .orElse(null);
+        assert queryResult != null;
+        return MainPage.makeMainPage(
+            queryResult.nickname(),
+            queryResult.readToastCount(),
+            queryResult.totalToastCount(),
+            queryResult.categories()
+        );
+    }
+
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/mainpage/MainPageQueryRepository.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/mainpage/MainPageQueryRepository.java
@@ -1,0 +1,9 @@
+package com.app.toaster.adapter.out.persistence.mainpage;
+
+import com.app.toaster.mainpage.vo.MainPageVO;
+
+import java.util.Optional;
+
+public interface MainPageQueryRepository {
+    Optional<MainPageVO> getMainPageData(Long userId);
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/mainpage/MainPageQueryRepositoryImpl.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/mainpage/MainPageQueryRepositoryImpl.java
@@ -1,0 +1,83 @@
+package com.app.toaster.adapter.out.persistence.mainpage;
+
+import com.app.toaster.adapter.out.persistence.clip.QClipEntity;
+import com.app.toaster.adapter.out.persistence.toast.QToastEntity;
+import com.app.toaster.adapter.out.persistence.user.QUserEntity;
+import com.app.toaster.mainpage.vo.CategoryToastCountVO;
+import com.app.toaster.mainpage.vo.MainPageVO;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Repository
+class MainPageQueryRepositoryImpl implements MainPageQueryRepository{
+
+    private final JPAQueryFactory queryFactory;
+    private final QToastEntity toast = QToastEntity.toastEntity;
+    private final QClipEntity clip = QClipEntity.clipEntity;
+    private final QUserEntity user = QUserEntity.userEntity;
+
+
+    public Optional<MainPageVO> getMainPageData(Long userId) {
+        List<Tuple> results = queryFactory
+            .select(
+                user.nickname,
+                clip.id,
+                clip.title,
+                // 서브쿼리로 각 집계값 조회
+                JPAExpressions.select(toast.count())
+                    .from(toast)
+                    .where(toast.userId.eq(userId)),
+                JPAExpressions.select(toast.count())
+                    .from(toast)
+                    .where(toast.userId.eq(userId).and(toast.isRead.isTrue())),
+                JPAExpressions.select(toast.count())
+                    .from(toast)
+                    .where(toast.clipId.eq(clip.id))
+            )
+            .from(user)
+            .leftJoin(clip).on(clip.ownerId.eq(user.userId))
+            .where(user.userId.eq(userId))
+            .fetch();
+
+        if (results.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // 결과 변환 로직
+        return Optional.of(buildMainPageVO(results));
+    }
+
+    private MainPageVO buildMainPageVO(List<Tuple> results) {
+        // 첫 번째 결과에서 공통 데이터 추출
+        Tuple firstResult = results.get(0);
+
+        String nickname = firstResult.get(user.nickname);
+        Integer totalToastCount = firstResult.get(4, Integer.class); // 전체 토스트 수
+        Integer readToastCount = firstResult.get(5, Integer.class);  // 읽은 토스트 수
+
+        // 클립별 데이터 변환 (null이 아닌 클립들만)
+        List<CategoryToastCountVO> categories = results.stream()
+            .filter(tuple -> tuple.get(clip.id) != null) // 클립이 있는 경우만
+            .map(tuple -> new CategoryToastCountVO(
+                tuple.get(clip.id),
+                tuple.get(clip.title),
+                tuple.get(6, Long.class) // 클립별 토스트 수
+            ))
+            .collect(Collectors.toList());
+
+        return new MainPageVO(
+            nickname != null ? nickname : "닉네임을 찾을 수 없습니다.",
+            totalToastCount != null ? totalToastCount : 0,
+            readToastCount != null ? readToastCount : 0,
+            categories
+        );
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/AllowPushPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/AllowPushPersistenceAdapter.java
@@ -1,0 +1,27 @@
+package com.app.toaster.adapter.out.persistence.user;
+
+import com.app.toaster.application.port.create_toast.out.FindClipOwnerPort;
+import com.app.toaster.application.port.user_allow_push.out.UpdateAllowPushPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class AllowPushPersistenceAdapter implements FindClipOwnerPort, UpdateAllowPushPort {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean existsById(Long userId) {
+        return userRepository.existsById(userId);
+    }
+
+    @Override
+    public void allowPush(long userId, boolean isAllowed) {
+        UserEntity user = userRepository.findById(userId).orElseThrow(
+            () -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        user.updateFcmIsAllowed(isAllowed);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/LoadUserInfoPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/LoadUserInfoPersistenceAdapter.java
@@ -1,8 +1,6 @@
 package com.app.toaster.adapter.out.persistence.user;
 
-import com.app.toaster.application.port.create_toast.out.FindClipOwnerPort;
 import com.app.toaster.application.port.load_user_setting.out.LoadUserPort;
-import com.app.toaster.application.port.user_allow_push.out.UpdateUserPort;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.NotFoundException;
 import com.app.toaster.user.models.ToasterUser;
@@ -11,26 +9,13 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-class UserPersistenceAdapter implements LoadUserPort, FindClipOwnerPort, UpdateUserPort {
+public class LoadUserInfoPersistenceAdapter implements LoadUserPort {
 
     private final UserRepository userRepository;
-
     @Override
     public ToasterUser findUser(long userId) {
         return UserMapper.toDomain(userRepository.findById(userId).orElseThrow(
             () -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()))
         );
-    }
-
-    @Override
-    public boolean existsById(Long userId) {
-        return userRepository.existsById(userId);
-    }
-
-    @Override
-    public void allowPush(long userId, boolean isAllowed) {
-        UserEntity user = userRepository.findById(userId).orElseThrow(
-            () -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
-        user.updateFcmIsAllowed(isAllowed);
     }
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UpdateOsPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UpdateOsPersistenceAdapter.java
@@ -1,0 +1,22 @@
+package com.app.toaster.adapter.out.persistence.user;
+
+import com.app.toaster.application.port.user_update_os.out.UpdateOsPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.NotFoundException;
+import com.app.toaster.user.enums.OsType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateOsPersistenceAdapter implements UpdateOsPort {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void updateOs(Long userId, OsType os) {
+        UserEntity user = userRepository.findById(userId).orElseThrow(
+            () -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        user.updateOs(os);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UpdateUniqueKeyPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UpdateUniqueKeyPersistenceAdapter.java
@@ -1,0 +1,20 @@
+package com.app.toaster.adapter.out.persistence.user;
+
+import com.app.toaster.application.port.make_unique_key.out.UpdateUniqueKeyPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class UpdateUniqueKeyPersistenceAdapter implements UpdateUniqueKeyPort {
+
+    private final UserRepository userRepository;
+    @Override
+    public void updateUniqueKey(String uniqueKey, Long userId) {
+        UserEntity user = userRepository.findById(userId).orElseThrow(
+            () -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        user.updateUniqueKey(uniqueKey);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserEntity.java
@@ -1,6 +1,8 @@
 package com.app.toaster.adapter.out.persistence.user;
 
 import com.app.toaster.entity.BaseTimeEntity;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.user.enums.OsType;
 import com.app.toaster.user.enums.SocialType;
 import jakarta.persistence.*;
@@ -54,6 +56,14 @@ class UserEntity extends BaseTimeEntity {
 
 	public void updateFcmIsAllowed(boolean isAllowed) {
 		this.fcmIsAllowed = isAllowed;
+	}
+
+	public void updateOs(OsType os) {
+		if (os != null) {
+			this.os = os;
+			return;
+		}
+		throw new CustomException(Error.BAD_REQUEST_OS, Error.BAD_REQUEST_OS.getMessage());
 	}
 
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserEntity.java
@@ -51,4 +51,9 @@ class UserEntity extends BaseTimeEntity {
 		this.socialId = socialId;
 		this.socialType = socialType;
 	}
+
+	public void updateFcmIsAllowed(boolean isAllowed) {
+		this.fcmIsAllowed = isAllowed;
+	}
+
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserEntity.java
@@ -47,6 +47,9 @@ class UserEntity extends BaseTimeEntity {
 	@Column(nullable = false)
 	private OsType os;
 
+	@Column(nullable = true)
+	private String uniqueKey;
+
 	@Builder
 	public UserEntity(String nickname, String socialId, SocialType socialType) {
 		this.nickname = nickname;
@@ -64,6 +67,14 @@ class UserEntity extends BaseTimeEntity {
 			return;
 		}
 		throw new CustomException(Error.BAD_REQUEST_OS, Error.BAD_REQUEST_OS.getMessage());
+	}
+
+	public void updateUniqueKey(String uniqueKey) {
+		if (uniqueKey != null && !uniqueKey.isBlank()) {
+			this.uniqueKey = uniqueKey;
+			return;
+		}
+		throw new CustomException(Error.BAD_REQUEST_UNIQUEKEY, Error.BAD_REQUEST_UNIQUEKEY.getMessage());
 	}
 
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserMapper.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserMapper.java
@@ -11,7 +11,8 @@ class UserMapper {
             user.getRefreshToken(),
             user.getFcmToken(),
             user.getFcmIsAllowed(),
-            user.getProfile()
+            user.getProfile(),
+            user.getOs()
         );
     }
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/user/UserPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.app.toaster.adapter.out.persistence.user;
 
 import com.app.toaster.application.port.create_toast.out.FindClipOwnerPort;
 import com.app.toaster.application.port.load_user_setting.out.LoadUserPort;
+import com.app.toaster.application.port.user_allow_push.out.UpdateUserPort;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.NotFoundException;
 import com.app.toaster.user.models.ToasterUser;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-class UserPersistenceAdapter implements LoadUserPort, FindClipOwnerPort {
+class UserPersistenceAdapter implements LoadUserPort, FindClipOwnerPort, UpdateUserPort {
 
     private final UserRepository userRepository;
 
@@ -24,5 +25,12 @@ class UserPersistenceAdapter implements LoadUserPort, FindClipOwnerPort {
     @Override
     public boolean existsById(Long userId) {
         return userRepository.existsById(userId);
+    }
+
+    @Override
+    public void allowPush(long userId, boolean isAllowed) {
+        UserEntity user = userRepository.findById(userId).orElseThrow(
+            () -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        user.updateFcmIsAllowed(isAllowed);
     }
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/port/convert_share_clip/in/ChangeClipVisibilityCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/convert_share_clip/in/ChangeClipVisibilityCommand.java
@@ -1,0 +1,10 @@
+package com.app.toaster.application.port.convert_share_clip.in;
+
+public record ChangeClipVisibilityCommand(
+    Long userId,
+    Long clipId
+) {
+    public static ChangeClipVisibilityCommand toCommand(Long userId, Long clipId){
+        return new ChangeClipVisibilityCommand(userId, clipId);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/convert_share_clip/in/ConvertShareClipVisibilityUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/convert_share_clip/in/ConvertShareClipVisibilityUseCase.java
@@ -1,0 +1,8 @@
+package com.app.toaster.application.port.convert_share_clip.in;
+
+import com.app.toaster.adapter.in.convert_visibility_share_clip.ChangeClipVisibilityResponse;
+
+public interface ConvertShareClipVisibilityUseCase {
+    ChangeClipVisibilityResponse changePrivateClipToShareClip(ChangeClipVisibilityCommand command);
+    ChangeClipVisibilityResponse changeShareClipToPrivateClip(ChangeClipVisibilityCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/convert_share_clip/out/ConvertShareClipPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/convert_share_clip/out/ConvertShareClipPort.java
@@ -1,0 +1,8 @@
+package com.app.toaster.application.port.convert_share_clip.out;
+
+import com.app.toaster.clip.model.Clip;
+
+public interface ConvertShareClipPort {
+    Clip convertShareClipToPrivate(Long userId, Long clipId);
+    Clip convertPrivateClipToShare(Long userId, Long clipId);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/create_share_clip/in/CreateShareClipCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/create_share_clip/in/CreateShareClipCommand.java
@@ -1,0 +1,12 @@
+package com.app.toaster.application.port.create_share_clip.in;
+
+import com.app.toaster.adapter.in.create_share_clip.CreateShareClipRequest;
+
+public record CreateShareClipCommand(
+    Long userId,
+    String title
+) {
+    public static CreateShareClipCommand toCommand(Long userId, CreateShareClipRequest request){
+        return new CreateShareClipCommand(userId, request.title());
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/create_share_clip/in/CreateShareClipUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/create_share_clip/in/CreateShareClipUseCase.java
@@ -1,0 +1,7 @@
+package com.app.toaster.application.port.create_share_clip.in;
+
+import com.app.toaster.adapter.in.create_share_clip.CreateShareClipResponse;
+
+public interface CreateShareClipUseCase {
+    CreateShareClipResponse createShareClip(CreateShareClipCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/create_share_clip/out/CreateShareClipPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/create_share_clip/out/CreateShareClipPort.java
@@ -1,0 +1,8 @@
+package com.app.toaster.application.port.create_share_clip.out;
+
+import com.app.toaster.clip.model.Clip;
+
+public interface CreateShareClipPort {
+
+    Clip createShareClip(Long userId, String title);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/load_mainpage/in/LoadMainPageCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/load_mainpage/in/LoadMainPageCommand.java
@@ -1,0 +1,10 @@
+package com.app.toaster.application.port.load_mainpage.in;
+
+public record LoadMainPageCommand(
+    Long userId
+) {
+    public static LoadMainPageCommand toCommand(Long userId) {
+        return new LoadMainPageCommand(userId);
+    }
+
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/load_mainpage/in/LoadMainPageResponse.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/load_mainpage/in/LoadMainPageResponse.java
@@ -1,0 +1,20 @@
+package com.app.toaster.application.port.load_mainpage.in;
+
+import com.app.toaster.mainpage.vo.CategoryToastCountVO;
+
+import java.util.List;
+
+public record LoadMainPageResponse(
+    String nickname,
+    int readToastNum,
+    int allToastNum,
+    List<CategoryToastCountVO> mainCategoryListDto) {
+    public static LoadMainPageResponse toResponse(String nickname, int readToastNum, int allToastNum, List<CategoryToastCountVO> mainCategoryListDto) {
+        return new LoadMainPageResponse(
+            nickname,
+            readToastNum,
+            allToastNum,
+            mainCategoryListDto
+        );
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/load_mainpage/in/LoadMainPageUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/load_mainpage/in/LoadMainPageUseCase.java
@@ -1,0 +1,5 @@
+package com.app.toaster.application.port.load_mainpage.in;
+
+public interface LoadMainPageUseCase {
+    LoadMainPageResponse loadMainPage(LoadMainPageCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/load_mainpage/out/LoadMainPagePort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/load_mainpage/out/LoadMainPagePort.java
@@ -1,0 +1,7 @@
+package com.app.toaster.application.port.load_mainpage.out;
+
+import com.app.toaster.mainpage.model.MainPage;
+
+public interface LoadMainPagePort {
+    MainPage loadMainPageData(Long userId);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/make_unique_key/ToasterUniqueKeyUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/make_unique_key/ToasterUniqueKeyUseCase.java
@@ -1,0 +1,10 @@
+package com.app.toaster.application.port.make_unique_key;
+
+import com.app.toaster.adapter.in.user_unique_key.MakeUniqueKeyResponse;
+import com.app.toaster.adapter.in.user_unique_key.UpdateUniqueKeyResponse;
+import com.app.toaster.application.port.make_unique_key.in.command.UpdateUniqueKeyCommand;
+
+public interface ToasterUniqueKeyUseCase {
+    MakeUniqueKeyResponse makeUniqueKey();
+    UpdateUniqueKeyResponse updateUniqueKey(UpdateUniqueKeyCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/make_unique_key/in/command/UpdateUniqueKeyCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/make_unique_key/in/command/UpdateUniqueKeyCommand.java
@@ -1,0 +1,10 @@
+package com.app.toaster.application.port.make_unique_key.in.command;
+
+public record UpdateUniqueKeyCommand(
+    String uniqueKey,
+    Long userId
+) {
+    public static UpdateUniqueKeyCommand ofCommand(String uniqueKey, Long userId){
+        return new UpdateUniqueKeyCommand(uniqueKey,userId);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/make_unique_key/out/UpdateUniqueKeyPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/make_unique_key/out/UpdateUniqueKeyPort.java
@@ -1,0 +1,7 @@
+package com.app.toaster.application.port.make_unique_key.out;
+
+import com.app.toaster.application.port.user.UpdateUserPort;
+
+public interface UpdateUniqueKeyPort extends UpdateUserPort {
+    void updateUniqueKey(String uniqueKey, Long userId);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user/UpdateUserPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user/UpdateUserPort.java
@@ -1,0 +1,4 @@
+package com.app.toaster.application.port.user;
+
+public interface UpdateUserPort {
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/in/UserAllowPushUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/in/UserAllowPushUseCase.java
@@ -1,7 +1,7 @@
 package com.app.toaster.application.port.user_allow_push.in;
 
 import com.app.toaster.adapter.in.user_allow_push.UpdateAllowedPushResponse;
-import com.app.toaster.adapter.in.user_allow_push.command.UpdateAllowedPushCommand;
+import com.app.toaster.application.port.user_allow_push.in.command.UpdateAllowedPushCommand;
 
 public interface UserAllowPushUseCase {
     UpdateAllowedPushResponse allowPush(UpdateAllowedPushCommand command);

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/in/UserAllowPushUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/in/UserAllowPushUseCase.java
@@ -1,0 +1,8 @@
+package com.app.toaster.application.port.user_allow_push.in;
+
+import com.app.toaster.adapter.in.user_allow_push.UpdateAllowedPushResponse;
+import com.app.toaster.adapter.in.user_allow_push.command.UpdateAllowedPushCommand;
+
+public interface UserAllowPushUseCase {
+    UpdateAllowedPushResponse allowPush(UpdateAllowedPushCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/in/command/UpdateAllowedPushCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/in/command/UpdateAllowedPushCommand.java
@@ -1,4 +1,4 @@
-package com.app.toaster.adapter.in.user_allow_push.command;
+package com.app.toaster.application.port.user_allow_push.in.command;
 
 import com.app.toaster.adapter.in.user_allow_push.UpdateAllowedPushRequest;
 

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/out/UpdateAllowPushPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/out/UpdateAllowPushPort.java
@@ -1,0 +1,7 @@
+package com.app.toaster.application.port.user_allow_push.out;
+
+import com.app.toaster.application.port.user.UpdateUserPort;
+
+public interface UpdateAllowPushPort extends UpdateUserPort {
+    void allowPush(long userId, boolean isAllowed);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/out/UpdateUserPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/out/UpdateUserPort.java
@@ -1,0 +1,5 @@
+package com.app.toaster.application.port.user_allow_push.out;
+
+public interface UpdateUserPort {
+    void allowPush(long userId, boolean isAllowed);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/out/UpdateUserPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user_allow_push/out/UpdateUserPort.java
@@ -1,5 +1,0 @@
-package com.app.toaster.application.port.user_allow_push.out;
-
-public interface UpdateUserPort {
-    void allowPush(long userId, boolean isAllowed);
-}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user_update_os/in/UpdateOsCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user_update_os/in/UpdateOsCommand.java
@@ -1,0 +1,12 @@
+package com.app.toaster.application.port.user_update_os.in;
+
+import com.app.toaster.user.enums.OsType;
+
+public record UpdateOsCommand(
+    Long userId,
+    OsType os
+) {
+    public static UpdateOsCommand ofCommand(Long userId, String os){
+        return new UpdateOsCommand(userId, OsType.valueOf(os));
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user_update_os/in/UpdateOsUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user_update_os/in/UpdateOsUseCase.java
@@ -1,0 +1,7 @@
+package com.app.toaster.application.port.user_update_os.in;
+
+import com.app.toaster.adapter.in.user_update_os.UpdateOsResponseDto;
+
+public interface UpdateOsUseCase {
+    UpdateOsResponseDto updateOs(UpdateOsCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/user_update_os/out/UpdateOsPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/user_update_os/out/UpdateOsPort.java
@@ -1,0 +1,8 @@
+package com.app.toaster.application.port.user_update_os.out;
+
+import com.app.toaster.application.port.user.UpdateUserPort;
+import com.app.toaster.user.enums.OsType;
+
+public interface UpdateOsPort extends UpdateUserPort {
+    void updateOs(Long userId, OsType os);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/convert_visivility_share_clip/ConvertVisibilityClipService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/convert_visivility_share_clip/ConvertVisibilityClipService.java
@@ -1,0 +1,26 @@
+package com.app.toaster.application.service.convert_visivility_share_clip;
+
+import com.app.toaster.adapter.in.convert_visibility_share_clip.ChangeClipVisibilityResponse;
+import com.app.toaster.application.port.convert_share_clip.in.ChangeClipVisibilityCommand;
+import com.app.toaster.application.port.convert_share_clip.in.ConvertShareClipVisibilityUseCase;
+import com.app.toaster.application.port.convert_share_clip.out.ConvertShareClipPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ConvertVisibilityClipService implements ConvertShareClipVisibilityUseCase {
+    private final ConvertShareClipPort convertShareClipPort;
+    @Override
+    @Transactional
+    public ChangeClipVisibilityResponse changePrivateClipToShareClip(ChangeClipVisibilityCommand command) {
+        return ChangeClipVisibilityResponse.toResponse(convertShareClipPort.convertPrivateClipToShare(command.userId(), command.clipId()));
+    }
+
+    @Override
+    @Transactional
+    public ChangeClipVisibilityResponse changeShareClipToPrivateClip(ChangeClipVisibilityCommand command) {
+        return ChangeClipVisibilityResponse.toResponse(convertShareClipPort.convertShareClipToPrivate(command.userId(), command.clipId()));
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/load_mainpage/LoadMainPageService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/load_mainpage/LoadMainPageService.java
@@ -1,0 +1,28 @@
+package com.app.toaster.application.service.load_mainpage;
+
+import com.app.toaster.application.port.load_mainpage.in.LoadMainPageCommand;
+import com.app.toaster.application.port.load_mainpage.in.LoadMainPageResponse;
+import com.app.toaster.application.port.load_mainpage.in.LoadMainPageUseCase;
+import com.app.toaster.application.port.load_mainpage.out.LoadMainPagePort;
+import com.app.toaster.mainpage.model.MainPage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LoadMainPageService implements LoadMainPageUseCase {
+
+    private final LoadMainPagePort loadMainPagePort;
+    @Override
+    @Transactional(readOnly = true)
+    public LoadMainPageResponse loadMainPage(LoadMainPageCommand command) {
+        MainPage mainPage = loadMainPagePort.loadMainPageData(command.userId());
+        return LoadMainPageResponse.toResponse(
+            mainPage.getNickname(),
+            mainPage.getReadToastNum(),
+            mainPage.getAllToastNum(),
+            mainPage.getToastcountList()
+        );
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/make_share_clip/CreateShareClipService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/make_share_clip/CreateShareClipService.java
@@ -1,0 +1,22 @@
+package com.app.toaster.application.service.make_share_clip;
+
+import com.app.toaster.adapter.in.create_share_clip.CreateShareClipResponse;
+import com.app.toaster.application.port.create_share_clip.in.CreateShareClipCommand;
+import com.app.toaster.application.port.create_share_clip.in.CreateShareClipUseCase;
+import com.app.toaster.application.port.create_share_clip.out.CreateShareClipPort;
+import com.app.toaster.clip.model.Clip;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+@Service
+@RequiredArgsConstructor
+public class CreateShareClipService implements CreateShareClipUseCase {
+
+    private final CreateShareClipPort createShareClipPort;
+    @Override
+    @Transactional
+    public CreateShareClipResponse createShareClip(CreateShareClipCommand command) {
+        Clip newClip = createShareClipPort.createShareClip(command.userId(), command.title());
+        return CreateShareClipResponse.toResponse(newClip);
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/make_unique_key/MakeUniqueKeyService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/make_unique_key/MakeUniqueKeyService.java
@@ -1,0 +1,46 @@
+package com.app.toaster.application.service.make_unique_key;
+
+import com.app.toaster.adapter.in.user_unique_key.MakeUniqueKeyResponse;
+import com.app.toaster.adapter.in.user_unique_key.UpdateUniqueKeyResponse;
+import com.app.toaster.application.port.make_unique_key.ToasterUniqueKeyUseCase;
+import com.app.toaster.application.port.make_unique_key.in.command.UpdateUniqueKeyCommand;
+import com.app.toaster.application.port.make_unique_key.out.UpdateUniqueKeyPort;
+import com.app.toaster.exception.model.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MakeUniqueKeyService implements ToasterUniqueKeyUseCase {
+
+    private final UpdateUniqueKeyPort updateUniqueKeyPort;
+
+    @Override
+    public MakeUniqueKeyResponse makeUniqueKey() {
+        return MakeUniqueKeyResponse.success(makeUniqueKeyString());
+    }
+
+    private String makeUniqueKeyString(){
+        return "TOASTER" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+
+    @Override
+    @Transactional
+    public UpdateUniqueKeyResponse updateUniqueKey(UpdateUniqueKeyCommand command) {
+        try {
+            updateUniqueKeyPort.updateUniqueKey(command.uniqueKey(), command.userId());
+            return UpdateUniqueKeyResponse.success();
+        }catch (BadRequestException e){
+            log.info("[UPDATEUNIQUEKEY ERROR] uniqueKey가 null입니다.");
+            return UpdateUniqueKeyResponse.fail();
+        }catch (Exception e){
+            log.info("[UPDATEUNIQUEKEY ERROR] uniqueKey가 업데이트 중 예기치 못한 에러 발생, userid = {}", command.userId());
+            return UpdateUniqueKeyResponse.fail();
+        }
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/user_allow_push/UserAllowPushService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/user_allow_push/UserAllowPushService.java
@@ -4,7 +4,7 @@ import com.app.toaster.adapter.in.user_allow_push.UpdateAllowedPushResponse;
 import com.app.toaster.adapter.in.user_allow_push.command.UpdateAllowedPushCommand;
 import com.app.toaster.application.port.load_user_setting.out.LoadUserPort;
 import com.app.toaster.application.port.user_allow_push.in.UserAllowPushUseCase;
-import com.app.toaster.application.port.user_allow_push.out.UpdateUserPort;
+import com.app.toaster.application.port.user_allow_push.out.UpdateAllowPushPort;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.BadRequestException;
 import com.app.toaster.user.models.ToasterUser;
@@ -16,14 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 class UserAllowPushService implements UserAllowPushUseCase {
     private final LoadUserPort loadUserPort;
-    private final UpdateUserPort updateUserPort;
+    private final UpdateAllowPushPort updateAllowPushPort;
 
     @Override
     @Transactional
     public UpdateAllowedPushResponse allowPush(UpdateAllowedPushCommand command) {
         ToasterUser user = loadUserPort.findUser(command.userId());
         validatePushAllowStatus(user, command.allowedPush());
-        updateUserPort.allowPush(user.getId(), command.allowedPush());
+        updateAllowPushPort.allowPush(user.getId(), command.allowedPush());
         return UpdateAllowedPushResponse.toResponse(command.allowedPush());
     }
 

--- a/toaster-api/src/main/java/com/app/toaster/application/service/user_allow_push/UserAllowPushService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/user_allow_push/UserAllowPushService.java
@@ -1,9 +1,9 @@
 package com.app.toaster.application.service.user_allow_push;
 
 import com.app.toaster.adapter.in.user_allow_push.UpdateAllowedPushResponse;
-import com.app.toaster.adapter.in.user_allow_push.command.UpdateAllowedPushCommand;
 import com.app.toaster.application.port.load_user_setting.out.LoadUserPort;
 import com.app.toaster.application.port.user_allow_push.in.UserAllowPushUseCase;
+import com.app.toaster.application.port.user_allow_push.in.command.UpdateAllowedPushCommand;
 import com.app.toaster.application.port.user_allow_push.out.UpdateAllowPushPort;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.BadRequestException;

--- a/toaster-api/src/main/java/com/app/toaster/application/service/user_allow_push/UserAllowPushService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/user_allow_push/UserAllowPushService.java
@@ -1,0 +1,36 @@
+package com.app.toaster.application.service.user_allow_push;
+
+import com.app.toaster.adapter.in.user_allow_push.UpdateAllowedPushResponse;
+import com.app.toaster.adapter.in.user_allow_push.command.UpdateAllowedPushCommand;
+import com.app.toaster.application.port.load_user_setting.out.LoadUserPort;
+import com.app.toaster.application.port.user_allow_push.in.UserAllowPushUseCase;
+import com.app.toaster.application.port.user_allow_push.out.UpdateUserPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.BadRequestException;
+import com.app.toaster.user.models.ToasterUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+class UserAllowPushService implements UserAllowPushUseCase {
+    private final LoadUserPort loadUserPort;
+    private final UpdateUserPort updateUserPort;
+
+    @Override
+    @Transactional
+    public UpdateAllowedPushResponse allowPush(UpdateAllowedPushCommand command) {
+        ToasterUser user = loadUserPort.findUser(command.userId());
+        validatePushAllowStatus(user, command.allowedPush());
+        updateUserPort.allowPush(user.getId(), command.allowedPush());
+        return UpdateAllowedPushResponse.toResponse(command.allowedPush());
+    }
+
+    private void validatePushAllowStatus(ToasterUser toasterUser, boolean isAllowed) {
+        if (isAllowed == toasterUser.getFcmIsAllowed()) {   //같은 경우면 에러가 날 수 있으니 에러 띄움.
+            throw new BadRequestException(Error.BAD_REQUEST_VALIDATION,
+                Error.BAD_REQUEST_VALIDATION.getMessage());
+        }
+    }
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/user_update_os/UserUpdateOsService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/user_update_os/UserUpdateOsService.java
@@ -1,0 +1,33 @@
+package com.app.toaster.application.service.user_update_os;
+
+import com.app.toaster.adapter.in.user_update_os.UpdateOsResponseDto;
+import com.app.toaster.application.port.user_update_os.in.UpdateOsCommand;
+import com.app.toaster.application.port.user_update_os.in.UpdateOsUseCase;
+import com.app.toaster.application.port.user_update_os.out.UpdateOsPort;
+import com.app.toaster.exception.model.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+class UserUpdateOsService implements UpdateOsUseCase {
+
+    private final UpdateOsPort updateOsPort;
+    @Override
+    @Transactional
+    public UpdateOsResponseDto updateOs(UpdateOsCommand command) {
+        try {
+            updateOsPort.updateOs(command.userId(), command.os());
+            return UpdateOsResponseDto.success();
+        }catch (BadRequestException e){
+            log.info("[UPDATEOS ERROR] os가 null입니다.");
+            return UpdateOsResponseDto.fail();
+        }catch (Exception e){
+            log.info("[UPDATEOS ERROR] os 업데이트 중 예기치 못한 에러 발생, userid = {}",command.userId());
+            return UpdateOsResponseDto.fail();
+        }
+    }
+}

--- a/toaster-common/src/main/java/com/app/toaster/exception/Error.java
+++ b/toaster-common/src/main/java/com/app/toaster/exception/Error.java
@@ -34,6 +34,7 @@ public enum Error {
 	MALFORMED_URL_EXEPTION(HttpStatus.BAD_REQUEST, "url 링크가 잘못된 것 같습니다."),
 	BAD_REQUEST_REMIND_TIME(HttpStatus.BAD_REQUEST, "RemindTime 값이 잘못요청 되었습니다."),
 	BAD_REQUEST_OS(HttpStatus.BAD_REQUEST, "OS 필드가 비어있습니다."),
+	BAD_REQUEST_UNIQUEKEY(HttpStatus.BAD_REQUEST, "uniquekey가 비어있습니다."),
 	INVALID_APPLE_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "유효하지않은 애플 퍼블릭 키 입니다."),
 	INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 아이덴티티 토큰입니다."),
 	REQUEST_METHOD_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 메소드입니다."),

--- a/toaster-common/src/main/java/com/app/toaster/exception/Error.java
+++ b/toaster-common/src/main/java/com/app/toaster/exception/Error.java
@@ -14,6 +14,7 @@ public enum Error {
 	 */
 	DUMMY_NOT_FOUND(HttpStatus.NOT_FOUND, "더미에 데이터가 덜 들어간 것 같아요"),
 	NOT_FOUND_USER_EXCEPTION(HttpStatus.NOT_FOUND, "찾을 수 없는 유저입니다."),
+	NOT_FOUND_CLIP_EXCEPTION(HttpStatus.NOT_FOUND, "찾을 수 없는 클립입니다."),
 	NOT_FOUND_TOAST_EXCEPTION(HttpStatus.NOT_FOUND, "찾을 수 없는 토스트 입니다."),
 	NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.NOT_FOUND, "s3 서비스에서 이미지를 찾을 수 없습니다."),
 	NOT_FOUND_TOAST_FILTER(HttpStatus.NOT_FOUND, "유효하지 않은 필터입니다."),
@@ -26,6 +27,7 @@ public enum Error {
 	 */
 	BAD_REQUEST_ISREAD(HttpStatus.BAD_REQUEST, "isRead 값이 잘못요청 되었습니다."),
 	BAD_REQUEST_ID(HttpStatus.BAD_REQUEST, "잘못된 id값입니다."),
+	BAD_REQUEST_VISIBILITY_CLIP(HttpStatus.BAD_REQUEST, "이미 요청 상태로 전환되어있습니다."),
 	BAD_REQUEST_EMPTY_URL(HttpStatus.BAD_REQUEST, "빈 url로는 저장할 수 없습니다."),
 
 	BAD_REQUEST_VALIDATION(HttpStatus.BAD_REQUEST, "유효한 값으로 요청을 다시 보내주세요."),
@@ -63,7 +65,7 @@ public enum Error {
 	UNPROCESSABLE_CREATE_TIMER_EXCEPTION(HttpStatus.UNPROCESSABLE_ENTITY, "이미 타이머가 존재하는 클립입니다."),
 	UNPROCESSABLE_PRESIGNEDURL_EXCEPTION(HttpStatus.UNPROCESSABLE_ENTITY, "presignedUrl 발급 중 에러가 발생했습니다."),
 	UNPROCESSABLE_KAKAO_SERVER_EXCEPTION(HttpStatus.UNPROCESSABLE_ENTITY, "카카오서버와 통신 중 오류가 발생했습니다."),
-
+	UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION(HttpStatus.UNPROCESSABLE_ENTITY, "멤버리스트 전환 중 실패"),
 
 	/**
 	 * 500 INTERNAL_SERVER_ERROR

--- a/toaster-common/src/main/java/com/app/toaster/exception/Error.java
+++ b/toaster-common/src/main/java/com/app/toaster/exception/Error.java
@@ -1,10 +1,9 @@
 package com.app.toaster.exception;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -34,6 +33,7 @@ public enum Error {
 	BAD_REQUEST_FILE_SIZE(HttpStatus.BAD_REQUEST, "파일크기가 잘못된 것 같습니다. 최대 5MB"),
 	MALFORMED_URL_EXEPTION(HttpStatus.BAD_REQUEST, "url 링크가 잘못된 것 같습니다."),
 	BAD_REQUEST_REMIND_TIME(HttpStatus.BAD_REQUEST, "RemindTime 값이 잘못요청 되었습니다."),
+	BAD_REQUEST_OS(HttpStatus.BAD_REQUEST, "OS 필드가 비어있습니다."),
 	INVALID_APPLE_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "유효하지않은 애플 퍼블릭 키 입니다."),
 	INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 아이덴티티 토큰입니다."),
 	REQUEST_METHOD_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 메소드입니다."),

--- a/toaster-common/src/main/java/com/app/toaster/exception/Success.java
+++ b/toaster-common/src/main/java/com/app/toaster/exception/Success.java
@@ -14,6 +14,8 @@ public enum Success {
 	CREATE_TOAST_SUCCESS(HttpStatus.CREATED, "토스트 저장이 완료 되었습니다."),
 	CREATE_UNIQUEKEY_SUCCESS(HttpStatus.CREATED, "유니크키 생성이 완료 되었습니다."),
 	CREATE_TIMER_SUCCESS(HttpStatus.CREATED, "새 타이머 생성 성공"),
+    CREATE_SHARE_CLIP_SUCCESS(HttpStatus.CREATED, "공유클립 생성이 완료 되었습니다."),
+
 
 	/**
 	 * 200 OK
@@ -33,6 +35,7 @@ public enum Success {
 	GET_DUPLICATED_SUCCESS(HttpStatus.OK, "중복 여부 체크 성공"),
 
   	LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
+    UPDATE_VISIBILITY_SHARE_CLIP_SUCCESS(HttpStatus.OK, "공유클립 visible state 변경 성공"),
 	RE_ISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
 	TOKEN_HEALTH_CHECKED_SUCCESS(HttpStatus.OK, "토큰 헬스체크 성공"),
 	SIGNOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),

--- a/toaster-common/src/main/java/com/app/toaster/exception/Success.java
+++ b/toaster-common/src/main/java/com/app/toaster/exception/Success.java
@@ -12,6 +12,7 @@ public enum Success {
 	 * 201 CREATED
 	 */
 	CREATE_TOAST_SUCCESS(HttpStatus.CREATED, "토스트 저장이 완료 되었습니다."),
+	CREATE_UNIQUEKEY_SUCCESS(HttpStatus.CREATED, "유니크키 생성이 완료 되었습니다."),
 	CREATE_TIMER_SUCCESS(HttpStatus.CREATED, "새 타이머 생성 성공"),
 
 	/**
@@ -49,6 +50,7 @@ public enum Success {
 	UPDATE_TIMER_DATETIME_SUCCESS(HttpStatus.OK, "타이머 시간/날짜 수정 완료"),
 	UPDATE_TIMER_COMMENT_SUCCESS(HttpStatus.OK, "타이머 코멘트 수정 완료"),
 	CHANGE_TIMER_ALARM_SUCCESS(HttpStatus.OK, "타이머 알람여부 수정 완료"),
+	UPDATE_UNIQUEKEY_SUCCESS(HttpStatus.OK, "uniquekey 수정 완료"),
 	PUSH_ALARM_PERIODIC_SUCCESS(HttpStatus.OK, "푸시알림 활성에 성공했습니다."),
 	PUSH_ALARM_SUCCESS(HttpStatus.OK, "푸시알림 전송에 성공했습니다."),
 	CLEAR_SCHEDULED_TASKS_SUCCESS(HttpStatus.OK, "스케줄러에서 예약된 작업을 제거했습니다."),

--- a/toaster-common/src/main/java/com/app/toaster/exception/Success.java
+++ b/toaster-common/src/main/java/com/app/toaster/exception/Success.java
@@ -1,9 +1,8 @@
 package com.app.toaster.exception;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -44,6 +43,7 @@ public enum Success {
 	UPDATE_PUSH_ALLOWED_SUCCESS(HttpStatus.OK, "푸시알림 수정 성공"),
 	UPDATE_TOAST_TITLE_SUCCESS(HttpStatus.OK, "토스트 제목 수정 성공"),
 	UPDATE_TOAST_CLIP_SUCCESS(HttpStatus.OK, "토스트 클립이동 성공"),
+	UPDATE_OS_SUCCESS(HttpStatus.OK, "os 반영 성공"),
 
 	UPDATE_ISREAD_SUCCESS(HttpStatus.OK, "열람여부 수정 완료"),
 	UPDATE_TIMER_DATETIME_SUCCESS(HttpStatus.OK, "타이머 시간/날짜 수정 완료"),

--- a/toaster-domain/src/main/java/com/app/toaster/clip/model/Clip.java
+++ b/toaster-domain/src/main/java/com/app/toaster/clip/model/Clip.java
@@ -1,0 +1,27 @@
+package com.app.toaster.clip.model;
+
+import com.app.toaster.toast.enums.ClipType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Clip {
+
+    private final Long id;
+    private String title;
+    private final Long ownerId;
+    private int priority;
+    private final ClipType type;
+    private String members;
+
+    @Builder
+    public Clip(Long id, String title, Long ownerId, int priority, ClipType type, String members) {
+        this.id = id;
+        this.title = title;
+        this.ownerId = ownerId;
+        this.priority = priority;
+        this.type = type;
+        this.members = members;
+    }
+
+}

--- a/toaster-domain/src/main/java/com/app/toaster/mainpage/model/MainPage.java
+++ b/toaster-domain/src/main/java/com/app/toaster/mainpage/model/MainPage.java
@@ -1,0 +1,27 @@
+package com.app.toaster.mainpage.model;
+
+import com.app.toaster.mainpage.vo.CategoryToastCountVO;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MainPage {
+
+    String nickname;
+    int readToastNum;
+    int allToastNum;
+    List<CategoryToastCountVO> toastcountList;
+
+    public MainPage(String nickname, int readToastNum, int allToastNum, List<CategoryToastCountVO> toastcountList) {
+        this.nickname = nickname;
+        this.readToastNum = readToastNum;
+        this.allToastNum = allToastNum;
+        this.toastcountList = toastcountList;
+    }
+
+    public static MainPage makeMainPage(String nickname, int readToastNum, int allToastNum, List<CategoryToastCountVO> toastcountList) {
+        return new MainPage(nickname, readToastNum, allToastNum, toastcountList);
+
+    }
+}

--- a/toaster-domain/src/main/java/com/app/toaster/mainpage/vo/CategoryToastCountVO.java
+++ b/toaster-domain/src/main/java/com/app/toaster/mainpage/vo/CategoryToastCountVO.java
@@ -1,0 +1,8 @@
+package com.app.toaster.mainpage.vo;
+
+public record CategoryToastCountVO(
+    Long categoryId,
+    String categoryTitle,
+    Long toastCount
+) {
+}

--- a/toaster-domain/src/main/java/com/app/toaster/mainpage/vo/MainPageVO.java
+++ b/toaster-domain/src/main/java/com/app/toaster/mainpage/vo/MainPageVO.java
@@ -1,0 +1,11 @@
+package com.app.toaster.mainpage.vo;
+
+import java.util.List;
+
+public record MainPageVO(
+    String nickname,
+    int totalToastCount,
+    int readToastCount,
+    List<CategoryToastCountVO> categories
+) {
+}

--- a/toaster-domain/src/main/java/com/app/toaster/user/enums/OsType.java
+++ b/toaster-domain/src/main/java/com/app/toaster/user/enums/OsType.java
@@ -1,5 +1,5 @@
 package com.app.toaster.user.enums;
 
 public enum OsType {
-	APPLE, ANDROID
+	IOS, ANDROID
 }

--- a/toaster-domain/src/main/java/com/app/toaster/user/models/ToasterUser.java
+++ b/toaster-domain/src/main/java/com/app/toaster/user/models/ToasterUser.java
@@ -1,5 +1,6 @@
 package com.app.toaster.user.models;
 
+import com.app.toaster.user.enums.OsType;
 import lombok.Getter;
 
 @Getter
@@ -12,8 +13,9 @@ public class ToasterUser {
     private String fcmToken;
     private Boolean fcmIsAllowed;
     private String profile;
+    private OsType os;
 
-    protected ToasterUser(Long id, String nickname, String socialId, String refreshToken, String fcmToken, Boolean fcmIsAllowed, String profile) {
+    protected ToasterUser(Long id, String nickname, String socialId, String refreshToken, String fcmToken, Boolean fcmIsAllowed, String profile, OsType os) {
         this.id = id;
         this.nickname = nickname;
         this.socialId = socialId;
@@ -21,14 +23,11 @@ public class ToasterUser {
         this.fcmToken = fcmToken;
         this.fcmIsAllowed = fcmIsAllowed;
         this.profile = profile;
+        this.os = os;
     }
 
-    public static ToasterUser createToasterUser(String nickname, String socialId, String refreshToken, String fcmToken, Boolean fcmIsAllowed, String profile){
-        return new ToasterUser(null, nickname, socialId, refreshToken, fcmToken, fcmIsAllowed, profile);
-    }
-
-    public void updateFcmIsAllowed(Boolean isAllowed) {
-        this.fcmIsAllowed = isAllowed;
+    public static ToasterUser createToasterUser(String nickname, String socialId, String refreshToken, String fcmToken, Boolean fcmIsAllowed, String profile, OsType os) {
+        return new ToasterUser(null, nickname, socialId, refreshToken, fcmToken, fcmIsAllowed, profile, os);
     }
 
 }

--- a/toaster-domain/src/main/java/com/app/toaster/user/models/ToasterUser.java
+++ b/toaster-domain/src/main/java/com/app/toaster/user/models/ToasterUser.java
@@ -26,4 +26,9 @@ public class ToasterUser {
     public static ToasterUser createToasterUser(String nickname, String socialId, String refreshToken, String fcmToken, Boolean fcmIsAllowed, String profile){
         return new ToasterUser(null, nickname, socialId, refreshToken, fcmToken, fcmIsAllowed, profile);
     }
+
+    public void updateFcmIsAllowed(Boolean isAllowed) {
+        this.fcmIsAllowed = isAllowed;
+    }
+
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #11

## 📋 구현 기능 명세
- [x] settings, mainpage(볼필요없지만 deprecated 처리), os 업데이트, 유저 구분을 위한 유니크키 생성, 유니크 키 수정 api 구현

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
기존 로직도 n+1 여지 있었던 코드라 옮기는 김에 querydsl로 조인해서 처리했는데, deprecated를 안해놨던 코드를 옮겻네요;; 
아까운김에 올렸습니다.(뷰 바뀌면 고쳐서쓰면 빠를듯)
os업데이트는 apple로 하면 저희 로그인 유형도 apple이 있어서 헷갈릴까봐 ios로 변경했습니다.
유니크 키 로직은 간단하게만 해놨습니다만, 테스트가 필요해보입니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
하다보니 crud관련된 port는 겹치는 부분이 있기도 하고, update는 해당 entity를 먼저 조회해서 더티체킹을 해야하다보니 patch처럼 부분적으로 변경되는 경우 뼈대가되는 인터페이스를 상속받는 포트를 만드는식으로 변경했습니다. 그런데 그렇다보니 잘못된 상위 포트 ex) UpdateUserPort를 주입받는 경우가 생길거같아서 abstract를 고려해볼까해서 의견이 궁금합니다.
다음 브랜치로 test 짜면서 예외케이스 찾으면서 명세서 작성예정입니다.

- 개발하면서 어떤 점이 궁금했는지
- UpdateUserPort 같은거 추상클래스같이 만드는거 괜찮아보이는지?

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [ ] 테스트

## 🚀 API Endpoint
- 
