### PR TITLE
[Feature/#13] 링크 update, delete 관련 api

### DIFF
--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/controller/CreateToastController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/controller/CreateToastController.java
@@ -1,6 +1,6 @@
 package com.app.toaster.adapter.in.create_toast.controller;
 
-import com.app.toaster.adapter.in.create_toast.request.CreateToastDto;
+import com.app.toaster.adapter.in.create_toast.request.CreateToastRequest;
 import com.app.toaster.application.port.create_toast.in.CreateToastUseCase;
 import com.app.toaster.application.port.create_toast.in.command.CreateToastCommand;
 import com.app.toaster.dto.ApiResponse;
@@ -25,7 +25,7 @@ class CreateToastController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public ApiResponse createToast(
 		// @UserId Long userId,
-		@RequestBody CreateToastDto requestDto
+		@RequestBody CreateToastRequest requestDto
 	) {
 		// todo-mh 임의로 userId 1L로 설정, 추후 변경
 		CreateToastCommand command = new CreateToastCommand(

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/request/CreateToastDto.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/request/CreateToastDto.java
@@ -1,6 +1,0 @@
-package com.app.toaster.adapter.in.create_toast.request;
-
-import jakarta.annotation.Nullable;
-
-public record CreateToastDto(String linkUrl, @Nullable Long clipId, boolean isTimerEnabled) {
-}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/request/CreateToastRequest.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/create_toast/request/CreateToastRequest.java
@@ -1,0 +1,6 @@
+package com.app.toaster.adapter.in.create_toast.request;
+
+import jakarta.annotation.Nullable;
+
+public record CreateToastRequest(String linkUrl, @Nullable Long clipId, boolean isTimerEnabled) {
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/delete_toast/DeleteToastController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/delete_toast/DeleteToastController.java
@@ -1,0 +1,44 @@
+package com.app.toaster.adapter.in.delete_toast;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.app.toaster.adapter.in.edit_toast_title.EditToastTitleRequest;
+import com.app.toaster.application.port.delete_toast.in.DeleteToastCommand;
+import com.app.toaster.application.port.delete_toast.in.DeleteToastUseCase;
+import com.app.toaster.application.port.edit_toast_title.in.EditToastTitleCommand;
+import com.app.toaster.application.port.edit_toast_title.in.EditToastTitleUseCase;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/toast")
+@Validated
+@Tag(name = "Toast", description = "토스트(링크 저장) 관련 API")
+class DeleteToastController {
+	private final DeleteToastUseCase deleteToastUseCase;
+
+	@Operation(summary = "토스트 삭제", description = "1개 이상의 링크 삭제")
+	@DeleteMapping
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse deleteToast(
+		// @UserId Long userId,
+		@RequestBody DeleteToastRequest request
+	) {
+		// todo-mh 임의로 userId 1L로 설정, 추후 변경
+		DeleteToastCommand command = DeleteToastCommand.toCommand(1L, request.toastIds());
+		deleteToastUseCase.deleteToast(command);
+		return ApiResponse.success(Success.DELETE_TOAST_SUCCESS);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/delete_toast/DeleteToastRequest.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/delete_toast/DeleteToastRequest.java
@@ -1,0 +1,8 @@
+package com.app.toaster.adapter.in.delete_toast;
+
+import java.util.List;
+
+public record DeleteToastRequest(
+	List<Long> toastIds
+) {
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/EditToastTitleController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/EditToastTitleController.java
@@ -1,0 +1,40 @@
+package com.app.toaster.adapter.in.edit_toast_title;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.app.toaster.application.port.edit_toast_title.in.EditToastTitleCommand;
+import com.app.toaster.application.port.edit_toast_title.in.EditToastTitleUseCase;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/toast")
+@Validated
+@Tag(name = "Toast", description = "토스트(링크 저장) 관련 API")
+class EditToastTitleController {
+	private final EditToastTitleUseCase editToastTitleUseCase;
+
+	@Operation(summary = "토스트 제목 수정", description = "링크 제목 수정")
+	@PatchMapping("/title")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse editToastTitle(
+		// @UserId Long userId,
+		@RequestBody EditToastTitleRequest request
+	) {
+		// todo-mh 임의로 userId 1L로 설정, 추후 변경
+		EditToastTitleCommand command = EditToastTitleCommand.toCommand(1L, request.toastId(), request.newTitle());
+		editToastTitleUseCase.editToastTitle(command);
+		return ApiResponse.success(Success.UPDATE_TOAST_TITLE_SUCCESS);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/EditToastTitleRequest.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/EditToastTitleRequest.java
@@ -1,0 +1,7 @@
+package com.app.toaster.adapter.in.edit_toast_title;
+
+public record EditToastTitleRequest(
+	Long toastId,
+	String newTitle
+) {
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/TitleValid.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/TitleValid.java
@@ -1,0 +1,19 @@
+package com.app.toaster.adapter.in.edit_toast_title;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = TitleValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+public @interface TitleValid {
+	String message() default "Invalid title";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+	String pattern() default "^[\\S][가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\\s]{0,20}$";
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/TitleValidator.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/TitleValidator.java
@@ -1,0 +1,63 @@
+package com.app.toaster.adapter.in.edit_toast_title;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class TitleValidator implements ConstraintValidator<TitleValid, String> {
+
+	private String pattern;
+	private Class<?>[] groups;
+	@Override
+	public void initialize(TitleValid constraintAnnotation) {
+		this.pattern = constraintAnnotation.pattern();
+		this.groups = constraintAnnotation.groups();
+	}
+
+	@Override
+	public boolean isValid(String title, ConstraintValidatorContext context) {
+		context.disableDefaultConstraintViolation();
+
+		if (title == null) {
+			context.buildConstraintViolationWithTemplate("제목에 null값이 들어옵니다.") //defaultMessage 생성
+				.addConstraintViolation();
+			return false;
+		}
+
+		// 커스텀 예외를 던집니다.
+		// null, 공백으로만 이뤄지는 경우, 빈 값인 경우 ''
+		if (title.isBlank()) {
+			context.buildConstraintViolationWithTemplate("제목이 공백으로만 차있습니다.") //defaultMessage 생성
+				.addConstraintViolation();
+			return false;
+		}
+		// 제목이 비어있는 경우
+		if (title.isEmpty()) {
+			context.buildConstraintViolationWithTemplate("제목이 비어있습니다. ")
+				.addConstraintViolation();
+			return false;
+		}
+
+		if(!isGroupActive(ToastValidationGroup.class) && title.length()>15){ //토스트쪽이 아니면 검증을 합니다.
+			context.buildConstraintViolationWithTemplate("이름은 최대 15자까지 입력 가능해요")
+					.addConstraintViolation();
+			return false;
+		}
+
+		if(!title.matches(pattern)){
+			context.buildConstraintViolationWithTemplate("특수 문자로는 검색할 수 없어요.")
+				.addConstraintViolation();
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean isGroupActive(Class<?> targetGroup) {
+		for (Class<?> group : groups) {
+			if (group.equals(targetGroup)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/ToastValidationGroup.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/ToastValidationGroup.java
@@ -1,4 +1,0 @@
-package com.app.toaster.adapter.in.edit_toast_title;
-
-public interface ToastValidationGroup {
-}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/ToastValidationGroup.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/ToastValidationGroup.java
@@ -1,0 +1,4 @@
+package com.app.toaster.adapter.in.edit_toast_title;
+
+public interface ToastValidationGroup {
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/UpdateToastDto.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/UpdateToastDto.java
@@ -1,6 +1,8 @@
 package com.app.toaster.adapter.in.edit_toast_title;
 
 import com.app.toaster.exception.Severity;
+import com.app.toaster.valid.TitleValid;
+import com.app.toaster.valid.ToastValidationGroup;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/UpdateToastDto.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/edit_toast_title/UpdateToastDto.java
@@ -1,0 +1,14 @@
+package com.app.toaster.adapter.in.edit_toast_title;
+
+import com.app.toaster.exception.Severity;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateToastDto(
+	Long toastId,
+	@TitleValid(payload = Severity.Error.class, groups = {ToastValidationGroup.class}) @NotNull String title
+) {
+	public static UpdateToastDto of(Long toastId, String title){
+		return new UpdateToastDto(toastId,title);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/read_toast/controller/ReadToastController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/read_toast/controller/ReadToastController.java
@@ -1,0 +1,41 @@
+package com.app.toaster.adapter.in.read_toast.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.app.toaster.adapter.in.read_toast.request.ReadToastRequest;
+import com.app.toaster.application.port.read_toast.in.ReadToastCommand;
+import com.app.toaster.application.port.read_toast.in.ReadToastUseCase;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/toast")
+@Validated
+@Tag(name = "Toast", description = "토스트(링크 저장) 관련 API")
+class ReadToastController {
+	private final ReadToastUseCase readToastUseCase;
+
+	@Operation(summary = "토스트 읽음 처리", description = "토스트 읽음 처리")
+	@PatchMapping("/read")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse createToast(
+		// @UserId Long userId,
+		@RequestBody ReadToastRequest request
+	) {
+		// todo-mh 임의로 userId 1L로 설정, 추후 변경
+		ReadToastCommand command = ReadToastCommand.toCommand(1L, request.toastId(), request.isRead());
+		readToastUseCase.readToast(command);
+		return ApiResponse.success(Success.UPDATE_ISREAD_SUCCESS);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/read_toast/request/ReadToastRequest.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/read_toast/request/ReadToastRequest.java
@@ -1,0 +1,4 @@
+package com.app.toaster.adapter.in.read_toast.request;
+
+public record ReadToastRequest(Long toastId, Boolean isRead) {
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/in/restore_toast/RestoreToastController.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/in/restore_toast/RestoreToastController.java
@@ -1,0 +1,46 @@
+package com.app.toaster.adapter.in.restore_toast;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.app.toaster.adapter.in.read_toast.request.ReadToastRequest;
+import com.app.toaster.application.port.read_toast.in.ReadToastCommand;
+import com.app.toaster.application.port.read_toast.in.ReadToastUseCase;
+import com.app.toaster.application.port.restore_toast.RestoreToastCommand;
+import com.app.toaster.application.port.restore_toast.RestoreToastUseCase;
+import com.app.toaster.dto.ApiResponse;
+import com.app.toaster.exception.Success;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.websocket.server.PathParam;
+import lombok.RequiredArgsConstructor;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/toast")
+@Validated
+@Tag(name = "Toast", description = "토스트(링크 저장) 관련 API")
+class RestoreToastController {
+	private final RestoreToastUseCase restoreToastUseCase;
+
+	@Operation(summary = "타버린 토스트 복구", description = "타버린 토스트 복구(저장기간+7일)")
+	@PatchMapping("/{toastId}/restore")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse restoreToast(
+		// @UserId Long userId,
+		@PathVariable Long toastId
+	) {
+		// todo-mh 임의로 userId 1L로 설정, 추후 변경
+		RestoreToastCommand command = RestoreToastCommand.toCommand(1L, toastId);
+		restoreToastUseCase.restoreToast(command);
+		return ApiResponse.success(Success.RESTORE_TOAST_SUCCESS);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastEntity.java
@@ -1,0 +1,33 @@
+package com.app.toaster.adapter.out.persistence.burned_toast;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+import com.app.toaster.burned_toast.enums.NotificationStatus;
+
+@Entity
+@Table(name = "burnedToast")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class BurnedToastEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private LocalDate burnedAt;
+	private Long toastId;
+	private NotificationStatus notificationStatus;
+
+	@Builder
+	public BurnedToastEntity(LocalDate burnedAt, Long toastId, NotificationStatus notificationStatus) {
+		this.burnedAt = burnedAt;
+		this.toastId = toastId;
+		this.notificationStatus = notificationStatus;
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastEntity.java
@@ -24,6 +24,8 @@ class BurnedToastEntity {
 	private Long toastId;
 	private NotificationStatus notificationStatus;
 
+	//todo 팝업매니저 id 추가
+
 	@Builder
 	public BurnedToastEntity(LocalDate burnedAt, Long toastId, NotificationStatus notificationStatus) {
 		this.burnedAt = burnedAt;

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastPersistenceAdapter.java
@@ -1,0 +1,15 @@
+package com.app.toaster.adapter.out.persistence.burned_toast;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class BurnedToastPersistenceAdapter implements BurnedToastPort{
+	private final BurnedToastRepository burnedToastRepository;
+	@Override
+	public void delete(Long toastId) {
+		burnedToastRepository.deleteByToastId(toastId);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastPort.java
@@ -1,0 +1,5 @@
+package com.app.toaster.adapter.out.persistence.burned_toast;
+
+public interface BurnedToastPort {
+	void delete(Long toastId);
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastRepository.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/burned_toast/BurnedToastRepository.java
@@ -1,0 +1,7 @@
+package com.app.toaster.adapter.out.persistence.burned_toast;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BurnedToastRepository extends JpaRepository<BurnedToastEntity,Long> {
+	void deleteByToastId(Long toastId);
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipPersistenceAdapter.java
@@ -1,6 +1,6 @@
 package com.app.toaster.adapter.out.persistence.clip;
 
-import com.app.toaster.application.port.CheckClipOwnerPort;
+import com.app.toaster.application.port.common.CheckClipOwnerPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/DeleteToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/DeleteToastPersistenceAdapter.java
@@ -1,0 +1,20 @@
+package com.app.toaster.adapter.out.persistence.toast;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.app.toaster.application.port.delete_toast.out.DeleteToastPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteToastPersistenceAdapter implements DeleteToastPort {
+	private final ToastRepository toastRepository;
+	@Override
+	public void deleteAll(List<Long> toastIds) {
+		List<ToastEntity> entities = toastRepository.findAllById(toastIds);
+		toastRepository.deleteAll(entities);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastEntity.java
@@ -54,4 +54,8 @@ class ToastEntity extends BaseTimeEntity {
 	public void setReadStatus(Boolean isRead){
 		this.isRead = isRead;
 	}
+
+	public void setTitle(String newTitle){
+		this.title = newTitle;
+	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastEntity.java
@@ -50,4 +50,8 @@ class ToastEntity extends BaseTimeEntity {
 		this.burnedAt = burnedAt;
 		this.thumbnailUrl = thumbnailUrl;
 	}
+
+	public void setReadStatus(Boolean isRead){
+		this.isRead = isRead;
+	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastEntity.java
@@ -1,12 +1,16 @@
 package com.app.toaster.adapter.out.persistence.toast;
 
 import com.app.toaster.entity.BaseTimeEntity;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 @Entity
 @Table(name = "toast")
@@ -35,12 +39,12 @@ class ToastEntity extends BaseTimeEntity {
 	@Column(columnDefinition = "TEXT")
 	private String thumbnailUrl;
 
-	private LocalDateTime burnedAt;
+	private LocalDate burnedAt;
 
 	private Boolean isTimerEnabled;
 
 	@Builder
-	public ToastEntity(Long userId, Long clipId, String title, String linkUrl, String thumbnailUrl, LocalDateTime burnedAt, boolean isTimerEnabled) {
+	public ToastEntity(Long userId, Long clipId, String title, String linkUrl, String thumbnailUrl, LocalDate burnedAt, boolean isTimerEnabled) {
 		this.userId = userId;
 		this.clipId = clipId;
 		this.title = title;
@@ -57,5 +61,12 @@ class ToastEntity extends BaseTimeEntity {
 
 	public void setTitle(String newTitle){
 		this.title = newTitle;
+	}
+
+	public void store() {
+		if(this.burnedAt.isAfter(LocalDate.now())){
+			throw new CustomException(Error.INTERNAL_SERVER_ERROR, "링크가 아직 타지않았어요");
+		}
+		this.burnedAt = LocalDate.now().plusDays(7);
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastPersistenceAdapter.java
@@ -1,19 +1,20 @@
 package com.app.toaster.adapter.out.persistence.toast;
 
+import com.app.toaster.application.port.CheckToastOwnerPort;
 import com.app.toaster.application.port.create_toast.out.SaveToastPort;
 import com.app.toaster.application.port.move_clip.out.UpdateToastClipPort;
 import com.app.toaster.toast.model.Toast;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class ToastPersistenceAdapter implements SaveToastPort, UpdateToastClipPort {
+public class ToastPersistenceAdapter implements SaveToastPort, CheckToastOwnerPort {
 
 	private final ToastRepository toastRepository;
-	private final ToastQueryRepository toastQueryRepository;
 
 	@Override
 	public void save(Toast toast) {
@@ -22,7 +23,7 @@ public class ToastPersistenceAdapter implements SaveToastPort, UpdateToastClipPo
 	}
 
 	@Override
-	public void updateToastClip(List<Long> ids, Long clipId) {
-		toastQueryRepository.bulkUpdateClipIdByIds(ids, clipId);
+	public boolean existsByIdAndUserId(Long toastId, Long userId) {
+		return toastRepository.existsByIdAndUserId(toastId, userId);
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastPersistenceAdapter.java
@@ -1,5 +1,7 @@
 package com.app.toaster.adapter.out.persistence.toast;
 
+import java.util.List;
+
 import com.app.toaster.application.port.common.CheckToastOwnerPort;
 import com.app.toaster.application.port.create_toast.out.SaveToastPort;
 import com.app.toaster.toast.model.Toast;
@@ -22,5 +24,11 @@ public class ToastPersistenceAdapter implements SaveToastPort, CheckToastOwnerPo
 	@Override
 	public boolean existsByIdAndUserId(Long toastId, Long userId) {
 		return toastRepository.existsByIdAndUserId(toastId, userId);
+	}
+
+	@Override
+	public boolean allOwnedByUser(Long userId, List<Long> toastIds) {
+		long count = toastRepository.countByIdInAndUserId(toastIds, userId);
+		return count == toastIds.size();
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastPersistenceAdapter.java
@@ -1,14 +1,11 @@
 package com.app.toaster.adapter.out.persistence.toast;
 
-import com.app.toaster.application.port.CheckToastOwnerPort;
+import com.app.toaster.application.port.common.CheckToastOwnerPort;
 import com.app.toaster.application.port.create_toast.out.SaveToastPort;
-import com.app.toaster.application.port.move_clip.out.UpdateToastClipPort;
 import com.app.toaster.toast.model.Toast;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastRepository.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastRepository.java
@@ -3,4 +3,5 @@ package com.app.toaster.adapter.out.persistence.toast;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ToastRepository extends JpaRepository<ToastEntity, Long> {
+	Boolean existsByIdAndUserId(Long toastId, Long userId);
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastRepository.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastRepository.java
@@ -1,7 +1,11 @@
 package com.app.toaster.adapter.out.persistence.toast;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ToastRepository extends JpaRepository<ToastEntity, Long> {
 	Boolean existsByIdAndUserId(Long toastId, Long userId);
+
+	long countByIdInAndUserId(List<Long> toastIds, Long userId);
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/UpdateToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/UpdateToastPersistenceAdapter.java
@@ -4,13 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import com.app.toaster.application.port.CheckToastOwnerPort;
-import com.app.toaster.application.port.create_toast.out.SaveToastPort;
 import com.app.toaster.application.port.move_clip.out.UpdateToastClipPort;
 import com.app.toaster.application.port.read_toast.out.UpdateToastPort;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
-import com.app.toaster.toast.model.Toast;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,10 +25,19 @@ public class UpdateToastPersistenceAdapter implements UpdateToastClipPort, Updat
 
 	@Override
 	public void changeReadStatus(Long toastId, Boolean isRead) {
-		ToastEntity entity = toastRepository.findById(toastId)
+		ToastEntity entity = getToastEntity(toastId);
+		entity.setReadStatus(isRead);
+	}
+
+	@Override
+	public void editToastTitle(Long toastId, String newTitle) {
+		ToastEntity entity = getToastEntity(toastId);
+		entity.setTitle(newTitle);
+	}
+
+	private ToastEntity getToastEntity(Long toastId){
+		return toastRepository.findById(toastId)
 			.orElseThrow(() -> new CustomException(Error.NOT_FOUND_TOAST_EXCEPTION,
 				Error.NOT_FOUND_TOAST_EXCEPTION.getMessage()));
-
-		entity.setReadStatus(isRead);
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/UpdateToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/UpdateToastPersistenceAdapter.java
@@ -1,0 +1,37 @@
+package com.app.toaster.adapter.out.persistence.toast;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.app.toaster.application.port.CheckToastOwnerPort;
+import com.app.toaster.application.port.create_toast.out.SaveToastPort;
+import com.app.toaster.application.port.move_clip.out.UpdateToastClipPort;
+import com.app.toaster.application.port.read_toast.out.UpdateToastPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.toast.model.Toast;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateToastPersistenceAdapter implements UpdateToastClipPort, UpdateToastPort {
+
+	private final ToastRepository toastRepository;
+	private final ToastQueryRepository toastQueryRepository;
+
+	@Override
+	public void updateToastClip(List<Long> ids, Long clipId) {
+		toastQueryRepository.bulkUpdateClipIdByIds(ids, clipId);
+	}
+
+	@Override
+	public void changeReadStatus(Long toastId, Boolean isRead) {
+		ToastEntity entity = toastRepository.findById(toastId)
+			.orElseThrow(() -> new CustomException(Error.NOT_FOUND_TOAST_EXCEPTION,
+				Error.NOT_FOUND_TOAST_EXCEPTION.getMessage()));
+
+		entity.setReadStatus(isRead);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/UpdateToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/UpdateToastPersistenceAdapter.java
@@ -35,6 +35,12 @@ public class UpdateToastPersistenceAdapter implements UpdateToastClipPort, Updat
 		entity.setTitle(newTitle);
 	}
 
+	@Override
+	public void restoreToast(Long toastId) {
+		ToastEntity entity = getToastEntity(toastId);
+		entity.store();
+	}
+
 	private ToastEntity getToastEntity(Long toastId){
 		return toastRepository.findById(toastId)
 			.orElseThrow(() -> new CustomException(Error.NOT_FOUND_TOAST_EXCEPTION,

--- a/toaster-api/src/main/java/com/app/toaster/application/port/CheckToastOwnerPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/CheckToastOwnerPort.java
@@ -1,0 +1,5 @@
+package com.app.toaster.application.port;
+
+public interface CheckToastOwnerPort {
+	boolean existsByIdAndUserId(Long toastId, Long userId);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/common/CheckClipOwnerPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/common/CheckClipOwnerPort.java
@@ -1,4 +1,4 @@
-package com.app.toaster.application.port;
+package com.app.toaster.application.port.common;
 
 public interface CheckClipOwnerPort {
 	boolean existsByIdAndUserId(Long clipId, Long userId);

--- a/toaster-api/src/main/java/com/app/toaster/application/port/common/CheckToastOwnerPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/common/CheckToastOwnerPort.java
@@ -1,5 +1,9 @@
 package com.app.toaster.application.port.common;
 
+import java.util.List;
+
 public interface CheckToastOwnerPort {
 	boolean existsByIdAndUserId(Long toastId, Long userId);
+
+	boolean allOwnedByUser(Long userId, List<Long> toastIds);
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/port/common/CheckToastOwnerPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/common/CheckToastOwnerPort.java
@@ -1,4 +1,4 @@
-package com.app.toaster.application.port;
+package com.app.toaster.application.port.common;
 
 public interface CheckToastOwnerPort {
 	boolean existsByIdAndUserId(Long toastId, Long userId);

--- a/toaster-api/src/main/java/com/app/toaster/application/port/delete_toast/in/DeleteToastCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/delete_toast/in/DeleteToastCommand.java
@@ -1,0 +1,12 @@
+package com.app.toaster.application.port.delete_toast.in;
+
+import java.util.List;
+
+public record DeleteToastCommand(
+	Long userId,
+	List<Long> toastIds
+) {
+	public static DeleteToastCommand toCommand(Long userId, List<Long> toastIds){
+		return new DeleteToastCommand(userId, toastIds);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/delete_toast/in/DeleteToastUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/delete_toast/in/DeleteToastUseCase.java
@@ -1,0 +1,5 @@
+package com.app.toaster.application.port.delete_toast.in;
+
+public interface DeleteToastUseCase {
+	public void deleteToast(DeleteToastCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/delete_toast/out/DeleteToastPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/delete_toast/out/DeleteToastPort.java
@@ -1,0 +1,7 @@
+package com.app.toaster.application.port.delete_toast.out;
+
+import java.util.List;
+
+public interface DeleteToastPort {
+	public void deleteAll(List<Long> toastIds);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/edit_toast_title/in/EditToastTitleCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/edit_toast_title/in/EditToastTitleCommand.java
@@ -1,0 +1,11 @@
+package com.app.toaster.application.port.edit_toast_title.in;
+
+public record EditToastTitleCommand(
+	Long userId,
+	Long toastId,
+	String newTitle
+) {
+	public static EditToastTitleCommand toCommand(Long userId, Long toastId, String newTitle){
+		return new EditToastTitleCommand(userId, toastId, newTitle);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/edit_toast_title/in/EditToastTitleUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/edit_toast_title/in/EditToastTitleUseCase.java
@@ -1,0 +1,5 @@
+package com.app.toaster.application.port.edit_toast_title.in;
+
+public interface EditToastTitleUseCase {
+	public void editToastTitle(EditToastTitleCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/in/ReadToastCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/in/ReadToastCommand.java
@@ -1,0 +1,9 @@
+package com.app.toaster.application.port.read_toast.in;
+
+public record ReadToastCommand(
+	Long userId, Long toastId, Boolean isRead
+) {
+	public static ReadToastCommand toCommand(Long userId, Long toastId, Boolean isRead){
+		return new ReadToastCommand(userId, toastId, isRead);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/in/ReadToastUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/in/ReadToastUseCase.java
@@ -1,0 +1,6 @@
+package com.app.toaster.application.port.read_toast.in;
+
+public interface ReadToastUseCase {
+
+	public void readToast(ReadToastCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/out/UpdateToastPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/out/UpdateToastPort.java
@@ -3,4 +3,6 @@ package com.app.toaster.application.port.read_toast.out;
 public interface UpdateToastPort {
 
 	public void changeReadStatus(Long toastId, Boolean isRead);
+
+	public void editToastTitle(Long toastId, String newTitle);
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/out/UpdateToastPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/out/UpdateToastPort.java
@@ -1,0 +1,6 @@
+package com.app.toaster.application.port.read_toast.out;
+
+public interface UpdateToastPort {
+
+	public void changeReadStatus(Long toastId, Boolean isRead);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/out/UpdateToastPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/read_toast/out/UpdateToastPort.java
@@ -2,7 +2,9 @@ package com.app.toaster.application.port.read_toast.out;
 
 public interface UpdateToastPort {
 
-	public void changeReadStatus(Long toastId, Boolean isRead);
+	void changeReadStatus(Long toastId, Boolean isRead);
 
-	public void editToastTitle(Long toastId, String newTitle);
+	void editToastTitle(Long toastId, String newTitle);
+
+	void restoreToast(Long aLong);
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/port/restore_toast/RestoreToastCommand.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/restore_toast/RestoreToastCommand.java
@@ -1,0 +1,7 @@
+package com.app.toaster.application.port.restore_toast;
+
+public record RestoreToastCommand(Long userId, Long toastId) {
+	public static RestoreToastCommand toCommand(Long userId, Long toastId){
+		return new RestoreToastCommand(userId, toastId);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/port/restore_toast/RestoreToastUseCase.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/restore_toast/RestoreToastUseCase.java
@@ -1,0 +1,5 @@
+package com.app.toaster.application.port.restore_toast;
+
+public interface RestoreToastUseCase {
+	public void restoreToast(RestoreToastCommand command);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/create_toast/SaveToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/create_toast/SaveToastService.java
@@ -1,6 +1,6 @@
 package com.app.toaster.application.service.create_toast;
 
-import com.app.toaster.application.port.CheckClipOwnerPort;
+import com.app.toaster.application.port.common.CheckClipOwnerPort;
 import com.app.toaster.application.port.create_toast.in.CreateToastUseCase;
 import com.app.toaster.application.port.create_toast.in.command.CreateToastCommand;
 import com.app.toaster.application.port.create_toast.out.FindClipOwnerPort;

--- a/toaster-api/src/main/java/com/app/toaster/application/service/create_toast/SaveToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/create_toast/SaveToastService.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Service
@@ -39,7 +40,7 @@ class SaveToastService implements CreateToastUseCase {
 
 		ParsedOgResult res = parseOgTagPort.parse(command.linkUrl());
 		String thumbnail = checkIsBasicImage(res.imageAdvanced());
-		LocalDateTime burnedAt = command.isTimerEnabled()? LocalDateTime.now().plusDays(7) : null;
+		LocalDate burnedAt = command.isTimerEnabled()? LocalDate.now().plusDays(7) : null;
 
 		Toast toast = Toast.create(command.userId(), command.clipId(), res.titleAdvanced(), command.linkUrl(), thumbnail, burnedAt, command.isTimerEnabled());
 		saveToastPort.save(toast);

--- a/toaster-api/src/main/java/com/app/toaster/application/service/delete_toast/DeleteToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/delete_toast/DeleteToastService.java
@@ -1,0 +1,38 @@
+package com.app.toaster.application.service.delete_toast;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.app.toaster.application.port.common.CheckToastOwnerPort;
+import com.app.toaster.application.port.delete_toast.in.DeleteToastCommand;
+import com.app.toaster.application.port.delete_toast.in.DeleteToastUseCase;
+import com.app.toaster.application.port.delete_toast.out.DeleteToastPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeleteToastService implements DeleteToastUseCase {
+
+	private final DeleteToastPort deleteToastPort;
+	private final CheckToastOwnerPort checkToastOwnerPort;
+
+	@Override
+	@Transactional
+	public void deleteToast(DeleteToastCommand command) {
+		validate(command.userId(), command.toastIds());
+		deleteToastPort.deleteAll(command.toastIds());
+	}
+
+	private void validate(Long userId, List<Long> toastIds){
+		if (!checkToastOwnerPort.allOwnedByUser(userId, toastIds)) {
+			throw new CustomException(Error.INVALID_USER_ACCESS, Error.INVALID_USER_ACCESS.getMessage());
+		}
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/edit_toast_title/EditToastTitleService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/edit_toast_title/EditToastTitleService.java
@@ -1,0 +1,24 @@
+package com.app.toaster.application.service.edit_toast_title;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.app.toaster.application.port.edit_toast_title.in.EditToastTitleCommand;
+import com.app.toaster.application.port.edit_toast_title.in.EditToastTitleUseCase;
+import com.app.toaster.application.port.read_toast.out.UpdateToastPort;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EditToastTitleService implements EditToastTitleUseCase {
+	private final UpdateToastPort updateToastPort;
+
+	@Override
+	@Transactional
+	public void editToastTitle(EditToastTitleCommand command) {
+		updateToastPort.editToastTitle(command.toastId(), command.newTitle());
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/move_clip/MoveClipService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/move_clip/MoveClipService.java
@@ -1,6 +1,6 @@
 package com.app.toaster.application.service.move_clip;
 
-import com.app.toaster.application.port.CheckClipOwnerPort;
+import com.app.toaster.application.port.common.CheckClipOwnerPort;
 import com.app.toaster.application.port.move_clip.in.MoveClipCommand;
 import com.app.toaster.application.port.move_clip.in.MoveClipUseCase;
 import com.app.toaster.application.port.move_clip.out.UpdateToastClipPort;

--- a/toaster-api/src/main/java/com/app/toaster/application/service/read_toast/ReadToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/read_toast/ReadToastService.java
@@ -1,0 +1,34 @@
+package com.app.toaster.application.service.read_toast;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.app.toaster.application.port.CheckToastOwnerPort;
+import com.app.toaster.application.port.read_toast.in.ReadToastCommand;
+import com.app.toaster.application.port.read_toast.in.ReadToastUseCase;
+import com.app.toaster.application.port.read_toast.out.UpdateToastPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReadToastService implements ReadToastUseCase {
+
+	private final CheckToastOwnerPort checkToastOwnerPort;
+	private final UpdateToastPort updateToastPort;
+
+	@Override
+	@Transactional
+	public void readToast(ReadToastCommand command) {
+		validate(command.userId(), command.toastId());
+		updateToastPort.changeReadStatus(command.toastId(), command.isRead());
+	}
+
+	private void validate(Long userId, Long toastId){
+		if (!checkToastOwnerPort.existsByIdAndUserId(toastId, userId)) {
+			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 토스트가 아닙니다.");
+		}
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/read_toast/ReadToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/read_toast/ReadToastService.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.app.toaster.application.port.CheckToastOwnerPort;
+import com.app.toaster.application.port.common.CheckToastOwnerPort;
 import com.app.toaster.application.port.read_toast.in.ReadToastCommand;
 import com.app.toaster.application.port.read_toast.in.ReadToastUseCase;
 import com.app.toaster.application.port.read_toast.out.UpdateToastPort;

--- a/toaster-api/src/main/java/com/app/toaster/application/service/restore_toast/RestoreToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/restore_toast/RestoreToastService.java
@@ -1,0 +1,41 @@
+package com.app.toaster.application.service.restore_toast;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.app.toaster.adapter.out.persistence.burned_toast.BurnedToastPort;
+import com.app.toaster.application.port.common.CheckToastOwnerPort;
+import com.app.toaster.application.port.read_toast.out.UpdateToastPort;
+import com.app.toaster.application.port.restore_toast.RestoreToastCommand;
+import com.app.toaster.application.port.restore_toast.RestoreToastUseCase;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RestoreToastService implements RestoreToastUseCase {
+
+	private final CheckToastOwnerPort checkToastOwnerPort;
+	private final UpdateToastPort updateToastPort;
+	private final BurnedToastPort burnedToastPort;
+
+	@Override
+	@Transactional
+	public void restoreToast(RestoreToastCommand command) {
+		validate(command.userId(), command.toastId());
+		updateToastPort.restoreToast(command.toastId());
+		burnedToastPort.delete(command.toastId());
+	}
+
+	private void validate(Long userId, Long toastId){
+		if (!checkToastOwnerPort.existsByIdAndUserId(toastId, userId)) {
+			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 토스트가 아닙니다.");
+		}
+	}
+
+
+}
+

--- a/toaster-common/src/main/java/com/app/toaster/exception/Severity.java
+++ b/toaster-common/src/main/java/com/app/toaster/exception/Severity.java
@@ -1,0 +1,8 @@
+package com.app.toaster.exception;
+
+import jakarta.validation.Payload;
+
+public class Severity {
+	public static class Info implements Payload {};
+	public static class Error implements Payload {};
+}

--- a/toaster-common/src/main/java/com/app/toaster/exception/Success.java
+++ b/toaster-common/src/main/java/com/app/toaster/exception/Success.java
@@ -58,6 +58,7 @@ public enum Success {
 	PUSH_ALARM_SUCCESS(HttpStatus.OK, "푸시알림 전송에 성공했습니다."),
 	CLEAR_SCHEDULED_TASKS_SUCCESS(HttpStatus.OK, "스케줄러에서 예약된 작업을 제거했습니다."),
 	UPDATE_POPUP_SUCCESS(HttpStatus.OK, "팝업 데이터 수정 성공"),
+	RESTORE_TOAST_SUCCESS(HttpStatus.OK, "토스트 복구 성공"),
 
 
 	/**

--- a/toaster-common/src/main/java/com/app/toaster/valid/TitleValid.java
+++ b/toaster-common/src/main/java/com/app/toaster/valid/TitleValid.java
@@ -1,4 +1,4 @@
-package com.app.toaster.adapter.in.edit_toast_title;
+package com.app.toaster.valid;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/toaster-common/src/main/java/com/app/toaster/valid/TitleValidator.java
+++ b/toaster-common/src/main/java/com/app/toaster/valid/TitleValidator.java
@@ -1,4 +1,4 @@
-package com.app.toaster.adapter.in.edit_toast_title;
+package com.app.toaster.valid;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/toaster-common/src/main/java/com/app/toaster/valid/ToastValidationGroup.java
+++ b/toaster-common/src/main/java/com/app/toaster/valid/ToastValidationGroup.java
@@ -1,0 +1,4 @@
+package com.app.toaster.valid;
+
+public interface ToastValidationGroup {
+}

--- a/toaster-domain/src/main/java/com/app/toaster/burned_toast/enums/NotificationStatus.java
+++ b/toaster-domain/src/main/java/com/app/toaster/burned_toast/enums/NotificationStatus.java
@@ -1,0 +1,5 @@
+package com.app.toaster.burned_toast.enums;
+
+public enum NotificationStatus {
+	PENDING, SUCCESS, FAILED
+}

--- a/toaster-domain/src/main/java/com/app/toaster/burned_toast/model/BurnedToast.java
+++ b/toaster-domain/src/main/java/com/app/toaster/burned_toast/model/BurnedToast.java
@@ -1,0 +1,22 @@
+package com.app.toaster.burned_toast.model;
+
+import java.time.LocalDate;
+
+import com.app.toaster.burned_toast.enums.NotificationStatus;
+
+import lombok.Getter;
+
+@Getter
+public class BurnedToast {
+	private final Long id;
+	private LocalDate burnedAt;
+	private final Long toastId;
+	private NotificationStatus notificationStatus;
+
+	public BurnedToast(Long id, LocalDate burnedAt, Long toastId, NotificationStatus notificationStatus) {
+		this.id = id;
+		this.burnedAt = burnedAt;
+		this.toastId = toastId;
+		this.notificationStatus = notificationStatus;
+	}
+}

--- a/toaster-domain/src/main/java/com/app/toaster/toast/model/Toast.java
+++ b/toaster-domain/src/main/java/com/app/toaster/toast/model/Toast.java
@@ -1,5 +1,6 @@
 package com.app.toaster.toast.model;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.springframework.cglib.core.Local;
@@ -18,11 +19,11 @@ public class Toast {
 	private String thumbnailUrl;
 	private final LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
-	private LocalDateTime burnedAt;
+	private LocalDate burnedAt;
 	private boolean isTimerEnabled;
 
 	public Toast(Long id, Long userId, Long clipId, String title, String linkUrl, Boolean isRead,
-		String thumbnailUrl, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime burnedAt, boolean isTimerEnabled) {
+		String thumbnailUrl, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDate burnedAt, boolean isTimerEnabled) {
 		this.id = id;
 		this.userId = userId;
 		this.clipId = clipId;
@@ -36,7 +37,7 @@ public class Toast {
 		this.isTimerEnabled = isTimerEnabled;
 	}
 
-	public static Toast create(Long userId, Long clipId, String title, String linkUrl, String thumbnailUrl, LocalDateTime burnedAt, boolean isTimerEnabled) {
+	public static Toast create(Long userId, Long clipId, String title, String linkUrl, String thumbnailUrl, LocalDate burnedAt, boolean isTimerEnabled) {
 		return new Toast(null, userId, clipId, title, linkUrl, null, thumbnailUrl, null, null, burnedAt, isTimerEnabled);
 	}
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #13 

## 📋 구현 기능 명세
- [x] 토스트 읽음 처리 api
- [x] 토스트 제목 수정 api
- [x] 토스트 삭제 api
- [x] 타버린 토스트 복구 api

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
링크 읽음 처리 api -> 읽음처리만 가능한지, 읽음에서 다시 미열람으로 상태 변경한지 몰라서 일단 둘다 해놨고(기존과 동일) 추후에 기획에 따라 수정하도록 하겠습니다.
타버린 토스트 복구 api -> 타버린 토스트 복구 시 현재날짜+7일로 burnedAt 수정하고, 타버린 토스트 테이블에서 해당 데이터 삭제
기존에 burnedAt이 LocalDateTIme 데이터 타입이었는데 시간은 사용하지않아 LocalDate 타입으로 수정하였습니다.

타버린 토스트에서 알람전송 상태는 boolean이 아닌 enum으로 표시하였습니다. PENDING, SUCCESS, FAILED

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지
패키지안에 기능별로 패키지를 나누니까 정리가 좀 안되는 느낌인데 도메인별로 패키지 나누고 그 안에 기능별로 패키지 나누는건 어떤가요...?

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
-[Patch] v2/toast/read
-[Patch] v2/toast/title
-[Delete] v2/toast
-[Patch] v2.toast/{toastId}/restore