### PR TITLE
[#20] fix : 토스터 공유클립 고려하여 검증로직 수정

### DIFF
--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipPersistenceAdapter.java
@@ -1,9 +1,13 @@
 package com.app.toaster.adapter.out.persistence.clip;
 
+import java.util.Objects;
+
 import com.app.toaster.application.port.common.CheckClipMemberPort;
 import com.app.toaster.application.port.common.CheckClipOwnerPort;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.toast.enums.ClipType;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -19,9 +23,15 @@ public class ClipPersistenceAdapter implements CheckClipOwnerPort, CheckClipMemb
             () -> new CustomException(Error.NOT_FOUND_CLIP_EXCEPTION, Error.NOT_FOUND_CLIP_EXCEPTION.getMessage())
         );
 
+        // 소유자라면 허용
+        if (Objects.equals(clipEntity.getOwnerId(), userId)) {
+            return true;
+        }
+
+        // 소유자가 아닌경우
         return switch (clipEntity.getType()) {
-            case PRIVATE -> existsByIdAndUserId(clipId, userId);
-            case SHARED -> checkUserInClipMember(clipId, userId);
+            case PRIVATE -> false;
+            case SHARED  -> checkUserInClipMember(clipId, userId);
         };
     }
 

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipPersistenceAdapter.java
@@ -14,6 +14,18 @@ public class ClipPersistenceAdapter implements CheckClipOwnerPort, CheckClipMemb
     private final ClipRepository clipRepository;
 
     @Override
+    public boolean checkClipPermission(Long clipId, Long userId) {
+        ClipEntity clipEntity = clipRepository.findById(clipId).orElseThrow(
+            () -> new CustomException(Error.NOT_FOUND_CLIP_EXCEPTION, Error.NOT_FOUND_CLIP_EXCEPTION.getMessage())
+        );
+
+        return switch (clipEntity.getType()) {
+            case PRIVATE -> existsByIdAndUserId(clipId, userId);
+            case SHARED -> checkUserInClipMember(clipId, userId);
+        };
+    }
+
+    @Override
     public boolean existsByIdAndUserId(Long clipId, Long userId) {
         return clipRepository.existsByIdAndOwnerId(clipId, userId);
     }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/BurnedToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/BurnedToastPersistenceAdapter.java
@@ -2,11 +2,13 @@ package com.app.toaster.adapter.out.persistence.toast;
 
 import org.springframework.stereotype.Component;
 
+import com.app.toaster.application.port.burn_toast.out.BurnedToastPort;
+
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class BurnedToastPersistenceAdapter implements BurnedToastPort{
+public class BurnedToastPersistenceAdapter implements BurnedToastPort {
 	private final BurnedToastRepository burnedToastRepository;
 	@Override
 	public void delete(Long toastId) {

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/LoadToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/LoadToastPersistenceAdapter.java
@@ -1,0 +1,25 @@
+package com.app.toaster.adapter.out.persistence.toast;
+
+import org.springframework.stereotype.Component;
+
+import com.app.toaster.application.port.load_toast.out.LoadToastPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.toast.model.Toast;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LoadToastPersistenceAdapter implements LoadToastPort {
+
+	private final ToastRepository toastRepository;
+
+	@Override
+	public Toast loadToast(Long toastId) {
+		ToastEntity entity = toastRepository.findById(toastId)
+			.orElseThrow(() -> new CustomException(Error.BAD_REQUEST_ID, Error.BAD_REQUEST_ID.getMessage()));
+
+		return ToastMapper.toDomain(entity);
+	}
+}

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastPersistenceAdapter.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/toast/ToastPersistenceAdapter.java
@@ -2,8 +2,11 @@ package com.app.toaster.adapter.out.persistence.toast;
 
 import java.util.List;
 
+import com.app.toaster.adapter.out.persistence.clip.ClipRepository;
 import com.app.toaster.application.port.common.CheckToastOwnerPort;
 import com.app.toaster.application.port.create_toast.out.SaveToastPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.toast.model.Toast;
 import lombok.RequiredArgsConstructor;
 

--- a/toaster-api/src/main/java/com/app/toaster/application/port/burn_toast/out/BurnedToastPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/burn_toast/out/BurnedToastPort.java
@@ -1,4 +1,4 @@
-package com.app.toaster.adapter.out.persistence.toast;
+package com.app.toaster.application.port.burn_toast.out;
 
 public interface BurnedToastPort {
 	void delete(Long toastId);

--- a/toaster-api/src/main/java/com/app/toaster/application/port/common/CheckClipOwnerPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/common/CheckClipOwnerPort.java
@@ -2,4 +2,7 @@ package com.app.toaster.application.port.common;
 
 public interface CheckClipOwnerPort {
 	boolean existsByIdAndUserId(Long clipId, Long userId);
+
+	boolean checkClipPermission(Long clipId, Long userId);
+
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/port/load_toast/out/LoadToastPort.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/port/load_toast/out/LoadToastPort.java
@@ -1,0 +1,7 @@
+package com.app.toaster.application.port.load_toast.out;
+
+import com.app.toaster.toast.model.Toast;
+
+public interface LoadToastPort {
+	Toast loadToast(Long toastId);
+}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/create_toast/SaveToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/create_toast/SaveToastService.java
@@ -51,7 +51,7 @@ class SaveToastService implements CreateToastUseCase {
 			throw new CustomException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage());
 		}
 
-		if (clipId != null && !checkClipOwnerPort.checkClipPermission(clipId, userId)) {
+		if (clipId != 0L && !checkClipOwnerPort.checkClipPermission(clipId, userId)) {
 			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 클립이 아닙니다.");
 		}
 	}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/create_toast/SaveToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/create_toast/SaveToastService.java
@@ -51,7 +51,7 @@ class SaveToastService implements CreateToastUseCase {
 			throw new CustomException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage());
 		}
 
-		if (clipId != null && !checkClipOwnerPort.existsByIdAndUserId(clipId, userId)) {
+		if (clipId != null && !checkClipOwnerPort.checkClipPermission(clipId, userId)) {
 			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 클립이 아닙니다.");
 		}
 	}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/delete_toast/DeleteToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/delete_toast/DeleteToastService.java
@@ -36,9 +36,9 @@ public class DeleteToastService implements DeleteToastUseCase {
 
 	private void validate(Long userId, List<Long> toastIds) {
 		toastIds.forEach(toastId -> {
-			Toast toast = loadToastPort.loadToast(toastId);
-			if (!checkClipOwnerPort.checkClipPermission(toast.getClipId(), userId)) {
-				throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 토스터에 대한 권한이 없습니다.");
+			Long clipId = loadToastPort.loadToast(toastId).getClipId();
+			if (clipId != 0L && !checkClipOwnerPort.checkClipPermission(clipId, userId)) {
+				throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 클립이 아닙니다.");
 			}
 		});
 	}

--- a/toaster-api/src/main/java/com/app/toaster/application/service/delete_toast/DeleteToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/delete_toast/DeleteToastService.java
@@ -5,12 +5,15 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.app.toaster.application.port.common.CheckClipOwnerPort;
 import com.app.toaster.application.port.common.CheckToastOwnerPort;
 import com.app.toaster.application.port.delete_toast.in.DeleteToastCommand;
 import com.app.toaster.application.port.delete_toast.in.DeleteToastUseCase;
 import com.app.toaster.application.port.delete_toast.out.DeleteToastPort;
+import com.app.toaster.application.port.load_toast.out.LoadToastPort;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.toast.model.Toast;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 public class DeleteToastService implements DeleteToastUseCase {
 
 	private final DeleteToastPort deleteToastPort;
-	private final CheckToastOwnerPort checkToastOwnerPort;
+	private final LoadToastPort loadToastPort;
+	private final CheckClipOwnerPort checkClipOwnerPort;
 
 	@Override
 	@Transactional
@@ -30,9 +34,12 @@ public class DeleteToastService implements DeleteToastUseCase {
 		deleteToastPort.deleteAll(command.toastIds());
 	}
 
-	private void validate(Long userId, List<Long> toastIds){
-		if (!checkToastOwnerPort.allOwnedByUser(userId, toastIds)) {
-			throw new CustomException(Error.INVALID_USER_ACCESS, Error.INVALID_USER_ACCESS.getMessage());
-		}
+	private void validate(Long userId, List<Long> toastIds) {
+		toastIds.forEach(toastId -> {
+			Toast toast = loadToastPort.loadToast(toastId);
+			if (!checkClipOwnerPort.checkClipPermission(toast.getClipId(), userId)) {
+				throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 토스터에 대한 권한이 없습니다.");
+			}
+		});
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/service/edit_toast_title/EditToastTitleService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/edit_toast_title/EditToastTitleService.java
@@ -31,9 +31,9 @@ public class EditToastTitleService implements EditToastTitleUseCase {
 	}
 
 	private void validate(Long userId, Long toastId){
-		Toast toast = loadToastPort.loadToast(toastId);
-		if (!checkClipOwnerPort.checkClipPermission(toast.getClipId(), userId)) {
-			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 토스터에 대한 권한이 없습니다.");
+		Long clipId = loadToastPort.loadToast(toastId).getClipId();
+		if (clipId != 0L && !checkClipOwnerPort.checkClipPermission(clipId, userId)) {
+			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 클립이 아닙니다.");
 		}
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/service/edit_toast_title/EditToastTitleService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/edit_toast_title/EditToastTitleService.java
@@ -3,9 +3,14 @@ package com.app.toaster.application.service.edit_toast_title;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.app.toaster.application.port.common.CheckClipOwnerPort;
 import com.app.toaster.application.port.edit_toast_title.in.EditToastTitleCommand;
 import com.app.toaster.application.port.edit_toast_title.in.EditToastTitleUseCase;
+import com.app.toaster.application.port.load_toast.out.LoadToastPort;
 import com.app.toaster.application.port.read_toast.out.UpdateToastPort;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.toast.model.Toast;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,10 +20,20 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class EditToastTitleService implements EditToastTitleUseCase {
 	private final UpdateToastPort updateToastPort;
+	private final LoadToastPort loadToastPort;
+	private final CheckClipOwnerPort checkClipOwnerPort;
 
 	@Override
 	@Transactional
 	public void editToastTitle(EditToastTitleCommand command) {
+		validate(command.userId(), command.toastId());
 		updateToastPort.editToastTitle(command.toastId(), command.newTitle());
+	}
+
+	private void validate(Long userId, Long toastId){
+		Toast toast = loadToastPort.loadToast(toastId);
+		if (!checkClipOwnerPort.checkClipPermission(toast.getClipId(), userId)) {
+			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 토스터에 대한 권한이 없습니다.");
+		}
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/service/read_toast/ReadToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/read_toast/ReadToastService.java
@@ -31,9 +31,9 @@ public class ReadToastService implements ReadToastUseCase {
 	}
 
 	private void validate(Long userId, Long toastId){
-		Toast toast = loadToastPort.loadToast(toastId);
-		if (!checkClipOwnerPort.checkClipPermission(toast.getClipId(), userId)) {
-			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 토스터에 대한 권한이 없습니다.");
+		Long clipId = loadToastPort.loadToast(toastId).getClipId();
+		if (clipId != 0L && !checkClipOwnerPort.checkClipPermission(clipId, userId)) {
+			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 클립이 아닙니다.");
 		}
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/service/read_toast/ReadToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/read_toast/ReadToastService.java
@@ -4,19 +4,23 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.app.toaster.application.port.common.CheckClipOwnerPort;
 import com.app.toaster.application.port.common.CheckToastOwnerPort;
+import com.app.toaster.application.port.load_toast.out.LoadToastPort;
 import com.app.toaster.application.port.read_toast.in.ReadToastCommand;
 import com.app.toaster.application.port.read_toast.in.ReadToastUseCase;
 import com.app.toaster.application.port.read_toast.out.UpdateToastPort;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.toast.model.Toast;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ReadToastService implements ReadToastUseCase {
 
-	private final CheckToastOwnerPort checkToastOwnerPort;
+	private final CheckClipOwnerPort checkClipOwnerPort;
+	private final LoadToastPort loadToastPort;
 	private final UpdateToastPort updateToastPort;
 
 	@Override
@@ -27,8 +31,9 @@ public class ReadToastService implements ReadToastUseCase {
 	}
 
 	private void validate(Long userId, Long toastId){
-		if (!checkToastOwnerPort.existsByIdAndUserId(toastId, userId)) {
-			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 토스트가 아닙니다.");
+		Toast toast = loadToastPort.loadToast(toastId);
+		if (!checkClipOwnerPort.checkClipPermission(toast.getClipId(), userId)) {
+			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 토스터에 대한 권한이 없습니다.");
 		}
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/service/restore_toast/RestoreToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/restore_toast/RestoreToastService.java
@@ -35,9 +35,9 @@ public class RestoreToastService implements RestoreToastUseCase {
 	}
 
 	private void validate(Long userId, Long toastId){
-		Toast toast = loadToastPort.loadToast(toastId);
-		if (!checkClipOwnerPort.checkClipPermission(toast.getClipId(), userId)) {
-			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 토스터에 대한 권한이 없습니다.");
+		Long clipId = loadToastPort.loadToast(toastId).getClipId();
+		if (clipId != 0L && !checkClipOwnerPort.checkClipPermission(clipId, userId)) {
+			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 클립이 아닙니다.");
 		}
 	}
 }

--- a/toaster-api/src/main/java/com/app/toaster/application/service/restore_toast/RestoreToastService.java
+++ b/toaster-api/src/main/java/com/app/toaster/application/service/restore_toast/RestoreToastService.java
@@ -3,13 +3,16 @@ package com.app.toaster.application.service.restore_toast;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.app.toaster.adapter.out.persistence.toast.BurnedToastPort;
+import com.app.toaster.application.port.burn_toast.out.BurnedToastPort;
+import com.app.toaster.application.port.common.CheckClipOwnerPort;
 import com.app.toaster.application.port.common.CheckToastOwnerPort;
+import com.app.toaster.application.port.load_toast.out.LoadToastPort;
 import com.app.toaster.application.port.read_toast.out.UpdateToastPort;
 import com.app.toaster.application.port.restore_toast.RestoreToastCommand;
 import com.app.toaster.application.port.restore_toast.RestoreToastUseCase;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.toast.model.Toast;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +21,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class RestoreToastService implements RestoreToastUseCase {
 
-	private final CheckToastOwnerPort checkToastOwnerPort;
+	private final LoadToastPort loadToastPort;
+	private final CheckClipOwnerPort checkClipOwnerPort;
 	private final UpdateToastPort updateToastPort;
 	private final BurnedToastPort burnedToastPort;
 
@@ -31,11 +35,10 @@ public class RestoreToastService implements RestoreToastUseCase {
 	}
 
 	private void validate(Long userId, Long toastId){
-		if (!checkToastOwnerPort.existsByIdAndUserId(toastId, userId)) {
-			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 유저의 토스트가 아닙니다.");
+		Toast toast = loadToastPort.loadToast(toastId);
+		if (!checkClipOwnerPort.checkClipPermission(toast.getClipId(), userId)) {
+			throw new CustomException(Error.UNAUTHORIZED_ACCESS, "해당 토스터에 대한 권한이 없습니다.");
 		}
 	}
-
-
 }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #20 

## 📋 구현 기능 명세
- [x] 토스터 검증로직 공유클립 고려로직 추가

## 📌 PR Point
**- 무슨 이유로 어떻게 코드를 변경했는지**
기존의 개인클립으로만 고려하여 검증했던 방식에서 해당 토스터의 클립이 개인클립인지 공유클립인지 구분하여 검증
- 개인클립일경우 userId가 해당 유저가 맞는지 검증
- 공유클립일경우 소유자이거나 해당 유저가 멤버에 포함되는지 검증

**- 어떤 부분에 리뷰어가 집중해야 하는지**

**- 개발하면서 어떤 점이 궁금했는지**
전체 클립일경우 클립 id를 0으로 요청해서 처리했던거같은데 현재도 그렇게 처리하는지...?
-> 이럴경우 클립 id가 0일경우 개인클립처럼 검증하도록 로직 추가


