### PR TITLE
[#23] feat: LongListToJsonConverter 추가 및 클립엔티티 members 타입 수정

### DIFF
--- a/toaster-api/build.gradle
+++ b/toaster-api/build.gradle
@@ -19,4 +19,6 @@ dependencies {
 
     //Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipEntity.java
@@ -88,9 +88,7 @@ class ClipEntity {
 	}
 
 	public boolean isUserInClipMembers(Long userId) {
-		ObjectMapper objectMapper = new ObjectMapper();
-		List<Long> memberList = objectMapper.convertValue(this.members, List.class);
-		if (memberList.contains(userId)) {
+		if (this.members.contains(userId)) {
 			return true;
 		}
 		return false;

--- a/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipEntity.java
+++ b/toaster-api/src/main/java/com/app/toaster/adapter/out/persistence/clip/ClipEntity.java
@@ -4,6 +4,7 @@ import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.BadRequestException;
 import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.toast.enums.ClipType;
+import com.app.toaster.util.LongListToJsonConverter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -34,7 +35,9 @@ class ClipEntity {
 	@Enumerated(EnumType.STRING)
 	private ClipType type;
 
-	private String members;
+	@Column(columnDefinition = "json")
+	@Convert(converter = LongListToJsonConverter.class)
+	private List<Long> members;
 
 	@Builder
 	public ClipEntity(String title, Long ownerId, int priority, ClipType clipType) {
@@ -62,35 +65,19 @@ class ClipEntity {
 	}
 
 	public void addMember(Long newMemberId) {
-		ObjectMapper objectMapper = new ObjectMapper();
-		try {
-			List<Long> memberList = objectMapper.convertValue(this.members, List.class);
-			memberList.add(newMemberId);
-			this.members = objectMapper.writeValueAsString(memberList);
-		} catch (Exception e) {
-			throw new CustomException(Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION, Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION.getMessage());
-		}
+		List<Long> newMembers = new java.util.ArrayList<>(this.members);
+		newMembers.add(newMemberId);
+		this.members = newMembers;
 	}
 
 	public void exitMember(Long exitMemberId) {
-		ObjectMapper objectMapper = new ObjectMapper();
-		try {
-			List<Long> memberList = objectMapper.convertValue(this.members, List.class);
-			memberList.remove(exitMemberId); //TODO: object로 하긴했는데, 이거 인덱스로 오인하고 지우진않겠지?
-			this.members = objectMapper.writeValueAsString(memberList);
-		} catch (Exception e) {
-			throw new CustomException(Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION, Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION.getMessage());
-		}
+		List<Long> newMembers = new java.util.ArrayList<>(this.members);
+		newMembers.remove(exitMemberId);
+		this.members = newMembers;
 	}
 
-	private String makeOnlyOwnerState() {
-		List<Long> list = List.of(ownerId);
-		ObjectMapper objectMapper = new ObjectMapper();
-		try {
-			return objectMapper.writeValueAsString(list);
-		} catch (Exception e) {
-			throw new CustomException(Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION, Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION.getMessage());
-		}
+	private List<Long> makeOnlyOwnerState() {
+		return List.of(ownerId);
 	}
 
 	private boolean isEmptyMemberList() {

--- a/toaster-api/src/test/java/com/app/toaster/adapter/out/persistence/clip/ClipEntityTest.java
+++ b/toaster-api/src/test/java/com/app/toaster/adapter/out/persistence/clip/ClipEntityTest.java
@@ -1,0 +1,65 @@
+package com.app.toaster.adapter.out.persistence.clip;
+
+import com.app.toaster.toast.enums.ClipType;
+import com.app.toaster.util.LongListToJsonConverter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ClipEntityTest {
+
+	@Autowired
+	private ClipRepository clipRepository;
+
+	@Test
+	@DisplayName("멤버 추가 및 삭제 시 JSON 컨버터 정상 작동")
+	void testAddAndRemoveMembers() {
+		// given
+		ClipEntity clip = ClipEntity.builder()
+			.title("테스트 클립")
+			.ownerId(1L)
+			.priority(1)
+			.clipType(ClipType.PRIVATE)
+			.build();
+		clip.changeShared();
+		ClipEntity savedClip = clipRepository.save(clip);
+
+
+		// when: 멤버 추가
+		savedClip.addMember(2L);
+		savedClip.addMember(3L);
+		clipRepository.saveAndFlush(savedClip);
+
+		// then: DB에 반영되었는지 확인
+		ClipEntity found = clipRepository.findById(savedClip.getId()).orElseThrow();
+		assertThat(found.getMembers()).containsExactlyInAnyOrder(1L, 2L, 3L);
+
+		// when: 멤버 제거
+		found.exitMember(2L);
+		clipRepository.saveAndFlush(found);
+
+		// then: 멤버 삭제 반영 확인
+		ClipEntity updated = clipRepository.findById(savedClip.getId()).orElseThrow();
+		assertThat(updated.getMembers()).containsExactlyInAnyOrder(1L, 3L);
+	}
+
+	@Test
+	void testJsonConverter() {
+		LongListToJsonConverter converter = new LongListToJsonConverter();
+		List<Long> members = List.of(1L, 2L, 3L);
+
+		String json = converter.convertToDatabaseColumn(members);
+		List<Long> result = converter.convertToEntityAttribute(json);
+
+		assertThat(result).containsExactly(1L, 2L, 3L);
+	}
+}

--- a/toaster-api/src/test/java/com/app/toaster/adapter/out/persistence/clip/TestConfiguration.java
+++ b/toaster-api/src/test/java/com/app/toaster/adapter/out/persistence/clip/TestConfiguration.java
@@ -1,0 +1,7 @@
+package com.app.toaster.adapter.out.persistence.clip;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestConfiguration {
+}

--- a/toaster-bootstrap/build.gradle
+++ b/toaster-bootstrap/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'junit:junit:4.13.1'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 }

--- a/toaster-common/src/main/java/com/app/toaster/util/LongListToJsonConverter.java
+++ b/toaster-common/src/main/java/com/app/toaster/util/LongListToJsonConverter.java
@@ -1,0 +1,35 @@
+package com.app.toaster.util;
+
+import java.util.List;
+
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class LongListToJsonConverter implements AttributeConverter<List<Long>, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<Long> attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (Exception e) {
+            throw new CustomException(Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION, Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION.getMessage());
+        }
+    }
+
+    @Override
+    public List<Long> convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<List<Long>>() {});
+        } catch (Exception e) {
+            throw new CustomException(Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION, Error.UNPROCESSABLE_ENTITY_CONVERT_EXCEPTION.getMessage());
+        }
+    }
+}

--- a/toaster-domain/src/main/java/com/app/toaster/clip/model/Clip.java
+++ b/toaster-domain/src/main/java/com/app/toaster/clip/model/Clip.java
@@ -1,5 +1,7 @@
 package com.app.toaster.clip.model;
 
+import java.util.List;
+
 import com.app.toaster.toast.enums.ClipType;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,10 +14,10 @@ public class Clip {
     private final Long ownerId;
     private int priority;
     private final ClipType type;
-    private String members;
+    private List<Long> members;
 
     @Builder
-    public Clip(Long id, String title, Long ownerId, int priority, ClipType type, String members) {
+    public Clip(Long id, String title, Long ownerId, int priority, ClipType type, List<Long> members) {
         this.id = id;
         this.title = title;
         this.ownerId = ownerId;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #23 

## 📋 구현 기능 명세
- [x] LongListToJsonConverter 추가
- [x] 클립엔티티 members List<Long> 타입으로 변경
- [x] 테스트 

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
String members로 관리하니 쿼리에서 찾기 어렵고 매번 타입을 바꿔서 값을 사용해야하는 불편함이있어 
conveter클래스를 만들어 아예 db에서 가져올때 List<Long> 형태로 가져올수있도록 하였습니다.

+ JSON 형식으로 mysql에 저장하면 JSON_CONTAINS 함수를 사용할수있다고 합니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
**혹시 바꿨을때 영향이 있는 다른곳이 있는지???**

- 개발하면서 어떤 점이 궁금했는지
테이블을 따로 빼는게 나을지 이게 나을지 고민이네욤...

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- 
